### PR TITLE
fix vscode settings.json files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "black",
+    "cairols.venvCommand": "source ./starknet/.venv/bin/activate",
+    "cairo.cairoFormatPath": "./starknet/.venv/bin/cairo-format",
 }

--- a/starknet/.vscode/settings.json
+++ b/starknet/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "cairols.venvCommand": "source ./.venv/bin/activate",
-  "cairo.cairoFormatPath": "./.venv/bin/cairo-format",
-  "python.formatting.provider": "black"
-}


### PR DESCRIPTION
the `nym-project/starknet/.vscode/settings.json` file wasn't applying for me when I ran `code .` in the root of our repository (looks like nested settings like that aren't supported yet? https://github.com/microsoft/vscode/issues/32693) so I moved those settings up a level to `nym-project/.vscode/settings.json`, and it's working now.

I like the idea of the nested settings, but doesn't seem fully supported!