### PR TITLE
Serialize arbitrarily-sized byte arrays to Felts

### DIFF
--- a/nym-dapp/web/config/tests.ts
+++ b/nym-dapp/web/config/tests.ts
@@ -1,0 +1,6 @@
+// Hacky polyfill, not sure why this is necessary since TextEncoder should be available by default in Node 14?
+// https://github.com/ipfs/js-ipfs/issues/3620
+// https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-definedin-jest
+import { TextEncoder, TextDecoder } from 'util'
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder

--- a/nym-dapp/web/package.json
+++ b/nym-dapp/web/package.json
@@ -24,6 +24,7 @@
     "@usedapp/core": "^0.5.4",
     "framer-motion": "^4",
     "ipfs-http-client": "^53.0.1",
+    "lodash": "^4.17.21",
     "prop-types": "15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -32,5 +33,9 @@
     "react-player": "^2.9.0",
     "react-webcam": "^6.0.0",
     "use-file-picker": "^1.4.0"
+  },
+  "devDependencies": {
+    "fast-check": "^2.18.0",
+    "web-encoding": "^1.1.5"
   }
 }

--- a/nym-dapp/web/src/lib/cairoSerializers.test.ts
+++ b/nym-dapp/web/src/lib/cairoSerializers.test.ts
@@ -1,0 +1,27 @@
+import '../../config/tests'
+import { CID } from 'ipfs-http-client'
+import fc from 'fast-check'
+import { bytesToFelts, feltsToBytes } from './cairoSerializers'
+
+describe('bytesToFelt / feltToBytes', () => {
+  test('CID round trip', async () => {
+    const cid = CID.parse('QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u')
+
+    const result = bytesToFelts(cid.bytes)
+    expect(result.length).toBe(2)
+    expect(feltsToBytes(result)).toEqual(cid.bytes)
+  })
+
+  test('never serializes to 0', (async) => {
+    const result = bytesToFelts(Uint8Array.from([0]))
+    expect(result).toEqual(1)
+  })
+
+  test('Property testing', () => {
+    fc.assert(
+      fc.property(fc.uint8Array({ min: 0, maxLength: 63 }), (array) =>
+        expect(feltsToBytes(bytesToFelts(array))).toEqual(array)
+      )
+    )
+  })
+})

--- a/nym-dapp/web/src/lib/cairoSerializers.ts
+++ b/nym-dapp/web/src/lib/cairoSerializers.ts
@@ -1,0 +1,41 @@
+import chunk from 'lodash/chunk'
+
+// The maximum number of bytes we can safely store in a Felt
+const FELT_MAX_BYTES = 31
+
+// Serialize a Uint8Array into an array of Felt-sized `BigInt`s, suitable for storing on StarkNet.
+export const bytesToFelts = (bytes: Uint8Array): bigint[] => {
+  // We want to return the same `bytes` array from `feltToBytes` that we received in
+  // `byteToFelts`, without adding or removing any padding. To achieve this, we'll
+  // record the number of significant bits in the first Felt as the first byte of the
+  // encoded list of felts.
+  const firstFeltSignificantBytes = bytes.length % FELT_MAX_BYTES
+  const firstFeltPadding = Array(
+    FELT_MAX_BYTES - firstFeltSignificantBytes - 1
+  ).fill(0)
+  const bytesToEncode = [firstFeltSignificantBytes].concat(
+    firstFeltPadding,
+    Array.from(bytes)
+  )
+  console.assert(
+    bytesToEncode.length % FELT_MAX_BYTES == 0,
+    `Error, padding not correctly applied! ([${bytesToEncode}], ${bytesToEncode.length})`
+  )
+
+  const bytesAsHex = bytesToEncode.map((b) => b.toString(16).padStart(2, '0'))
+
+  return chunk(bytesAsHex, FELT_MAX_BYTES).map((chunk) =>
+    BigInt('0x' + chunk.join(''))
+  )
+}
+
+// Deserializes an array of Felt-sized `BigInt`s serialized with the corresponding `bytesToFelts` function back into the original `Uint8Array`.
+export const feltsToBytes = (felts: bigint[]): Uint8Array => {
+  const hexString = felts
+    .map((felt) => felt.toString(16).padStart(FELT_MAX_BYTES * 2, '0'))
+    .join('')
+
+  const byteArray = chunk(hexString, 2).map((hex) => parseInt(hex.join(''), 16))
+  const totalPadding = FELT_MAX_BYTES - byteArray[0]
+  return new Uint8Array(byteArray.slice(totalPadding))
+}

--- a/nym-dapp/yarn.lock
+++ b/nym-dapp/yarn.lock
@@ -5834,6 +5834,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -6408,6 +6413,11 @@ autoprefixer@^9.8.6:
     picocolors "^0.2.1"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 axe-core@^4.0.2, axe-core@^4.2.0:
   version "4.3.3"
@@ -9091,7 +9101,7 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.1.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1:
+es-abstract@^1.18.5, es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
   integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
@@ -9693,6 +9703,13 @@ extract-files@^9.0.0:
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
   integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
 
+fast-check@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.18.0.tgz#0337d82e7d7cb4eed5806c42b9e61ed0fb6592b2"
+  integrity sha512-7KKUw0wtAJOVrJ1DgmFILd9EmeqMLGtfe5HoEtkYZfYIxohm6Zy7zPq1Zl8t6tPL8A3e86YZrheyGg2m5j8cLA==
+  dependencies:
+    pure-rand "^5.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -10036,6 +10053,11 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
 foreground-child@^2.0.0:
   version "2.0.0"
@@ -11653,6 +11675,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@4.0.3, is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -11867,6 +11896,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
     has-symbols "^1.0.2"
+
+is-typed-array@^1.1.3, is-typed-array@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
+  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -15468,6 +15508,11 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+pure-rand@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.0.tgz#87f5bdabeadbd8904e316913a5c0b8caac517b37"
+  integrity sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
+
 qs@6.10.1, qs@^6.10.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
@@ -18289,6 +18334,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.3:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -18498,6 +18555,15 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"
@@ -18849,6 +18915,18 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-typed-array@^1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.7.tgz#2761799b9a22d4b8660b3c1b40abaa7739691793"
+  integrity sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.7"
 
 which@^1.2.14, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Since Starknet only gives us Felts to work with for on-chain storage, I wrote a set of somewhat homebrew serialization/deserialization functions to convert between an array of bytes and array of Felts.

I think it would be helpful to get another pair of eyes on this -- the code ended up both longer and more complex than I expected, so would appreciate a sanity check that I'm not missing an easier way to do this and didn't included any obvious bugs.