### PR TITLE
DRAFT: Refactor to read seeds from another file

### DIFF
--- a/starknet/contracts/seed_profiles.cairo
+++ b/starknet/contracts/seed_profiles.cairo
@@ -1,0 +1,46 @@
+from starkware.cairo.common.alloc import alloc
+
+from profile import Profile
+
+func _get_seed_profiles() -> (profiles_len : felt, profiles : Profile*):
+    let profiles : Profile* = alloc()
+
+    assert profiles[0] = Profile(
+        cid=2540330837585055780539510783934115607915723316677950747298602475656452204,
+        ethereum_address=12304345,
+        submitter_address=23452345,
+        submission_timestamp=2345,
+        is_notarized=1,
+        last_recorded_status=0,
+        challenge_timestamp=0,
+        challenger_address=0,
+        challenge_evidence_cid=0,
+        owner_evidence_cid=0,
+        adjudication_timestamp=0,
+        adjudicator_evidence_cid=0,
+        did_adjudicator_verify_profile=0,
+        appeal_timestamp=0,
+        super_adjudication_timestamp=0,
+        did_super_adjudicator_verify_profile=0
+        )
+    assert profiles[1] = Profile(
+        cid=2540330871370158362645699064512463112286950257735777688725356692623268826,
+        is_notarized=1,
+        appeal_timestamp=0,
+        ethereum_address=12304345,
+        submitter_address=23452345,
+        challenger_address=0,
+        owner_evidence_cid=0,
+        challenge_timestamp=0,
+        last_recorded_status=0,
+        submission_timestamp=2345,
+        adjudication_timestamp=0,
+        challenge_evidence_cid=0,
+        adjudicator_evidence_cid=0,
+        super_adjudication_timestamp=0,
+        did_adjudicator_verify_profile=0,
+        did_super_adjudicator_verify_profile=0
+        )
+
+    return (2, profiles)
+end

--- a/starknet/contracts/zorro.cairo
+++ b/starknet/contracts/zorro.cairo
@@ -20,6 +20,7 @@ from profile import (
     Profile, StatusEnum, _get_current_status, _get_did_adjudication_occur,
     _get_did_super_adjudication_occur, _get_is_in_provisional_time_window, _get_is_verified,
     _get_dict_from_profile, _get_profile_from_dict)
+from seed_profiles import _get_seed_profiles
 
 #
 # Storage vars
@@ -752,29 +753,22 @@ func _test_add_seed_profiles{pedersen_ptr : HashBuiltin*, range_check_ptr, sysca
     let (is_in_test_mode) = _is_in_test_mode.read()
     assert is_in_test_mode = 1
 
-    # Prevent griefers from screwing around if we're deployed in test mode on
-    # a public testnet
-    assert_caller_is_admin()
+    let (profiles_len : felt, profiles : Profile*) = _get_seed_profiles()
+    _test_add_seed_profiles_inner(0, profiles_len, profiles)
 
-    _test_add_seed_profile(
-        Profile(
-        cid=2540330837585055780539510783934115607915723316677950747298602475656452204,
-        ethereum_address=12304345,
-        submitter_address=23452345,
-        submission_timestamp=2345,
-        is_notarized=1,
-        last_recorded_status=StatusEnum.NOT_CHALLENGED,
-        challenge_timestamp=0,
-        challenger_address=0,
-        challenge_evidence_cid=0,
-        owner_evidence_cid=0,
-        adjudication_timestamp=0,
-        adjudicator_evidence_cid=0,
-        did_adjudicator_verify_profile=0,
-        appeal_timestamp=0,
-        super_adjudication_timestamp=0,
-        did_super_adjudicator_verify_profile=0
-        ))
+    return ()
+end
+
+func _test_add_seed_profiles_inner{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        n : felt, profiles_len : felt, profiles : Profile*):
+    if n == profiles_len:
+        return ()
+    end
+
+    _test_add_seed_profile(profiles[n])
+    
+    _test_add_seed_profiles_inner(n + 1, profiles_len, profiles)
 
     return ()
 end

--- a/starknet/test/test.py
+++ b/starknet/test/test.py
@@ -584,3 +584,16 @@ async def test_settle_where_challenger_would_win_reward_but_for_empty_security_p
     assert deltas["challenger"] == 0
     assert deltas["zorro"] == 0
     assert deltas["zorro_security_pool"] == 0
+
+@pytest.mark.asyncio
+async def test_adding_seed_profiles(
+    ctx_factory,
+):
+    ctx = ctx_factory()
+
+    await ctx.zorro._test_add_seed_profiles().invoke()
+
+    (num_profiles,) = (
+        await ctx.zorro.get_num_profiles().call()
+    ).result
+    assert num_profiles > 0

--- a/web/scripts/exportSeedProfiles.ts
+++ b/web/scripts/exportSeedProfiles.ts
@@ -1,0 +1,28 @@
+// To access your database
+import {db} from '$api/src/lib/db'
+import BN from 'bn.js'
+import {mapValues} from 'lodash'
+
+const hexToBN = (hex: string) => new BN(hex.replace('0x', ''), 16).toString(10)
+
+export default async ({args}) => {
+  const profiles = await db.cachedProfile.findMany()
+
+  profiles.forEach((profile) => {
+    console.log(
+      `\n\nPROFILE #${profile.id} (http://localhost:8910/profiles/${profile.id})`
+    )
+
+    const obj = mapValues(profile.cache as object, hexToBN)
+    const serializedObject = Object.entries(obj)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(',\n      ')
+
+    console.log(`
+    Profile(
+      ${serializedObject}
+    )
+
+`)
+  })
+}


### PR DESCRIPTION
This compiles, but the call to `_test_add_seed_profiles` in the deploy contract fails. Started trying to debug that but StarkNet seems to have temporarily gone down (?) during testing since unrelated parts of the deploy script started failing. Will circle back to this later.