### PR TITLE
Cache profile CIDs

### DIFF
--- a/redwood/.env.defaults
+++ b/redwood/.env.defaults
@@ -4,8 +4,8 @@
 # into version control.
 
 CHAIN_DEPLOYMENT=development
-DATABASE_URL=postgres://postgres@localhost:5432/nym_dev?connection_limit=1
-TEST_DATABASE_URL=postgres://postgres@localhost:5432/nym_tests?connection_limit=1
+DATABASE_URL=postgres://postgres@localhost:5432/zorro_dev?connection_limit=1
+TEST_DATABASE_URL=postgres://postgres@localhost:5432/zorro_tests?connection_limit=1
 
 # location of the test database for api service scenarios (defaults to ./.redwood/test.db if not set)
 

--- a/redwood/api/db/migrations/20220103153259_cache_cid_lookups/migration.sql
+++ b/redwood/api/db/migrations/20220103153259_cache_cid_lookups/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "CachedProfile_cid_idx" ON "CachedProfile"("cid");

--- a/redwood/api/db/schema.prisma
+++ b/redwood/api/db/schema.prisma
@@ -104,16 +104,17 @@ model CachedProfile {
   updatedAt DateTime @updatedAt
 
   connections Connection[]
+
+  @@index([cid])
 }
 
-
 model Connection {
-  id Int @id @default(autoincrement()) 
+  id Int @id @default(autoincrement())
 
-  profileId Int
+  profileId         Int
   purposeIdentifier String
-  externalAddress String
-  signature String // signature from profile owner
+  externalAddress   String
+  signature         String // signature from profile owner
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/redwood/api/src/lib/serializers.test.ts
+++ b/redwood/api/src/lib/serializers.test.ts
@@ -1,5 +1,3 @@
-// import {}
-
 import {parseAddress} from './serializers'
 
 describe('parseAddress', () => {

--- a/redwood/api/src/lib/starknet.ts
+++ b/redwood/api/src/lib/starknet.ts
@@ -198,6 +198,7 @@ export async function exportProfileById(profileId: number) {
     num_profiles: Felt
     current_status: Felt
     is_verified: Felt
+    now: Felt
   }
 
   return profile

--- a/redwood/package.json
+++ b/redwood/package.json
@@ -8,7 +8,6 @@
     ]
   },
   "scripts": {
-    "db:reset": "rm -rf api/db/migrations/ && echo 'y' | yarn rw prisma migrate dev --name init_db && yarn rw prisma db seed",
     "dev": "rw dev"
   },
   "devDependencies": {

--- a/redwood/scripts/seed.ts
+++ b/redwood/scripts/seed.ts
@@ -1,12 +1,10 @@
-import importPoH from 'api/db/seed/importPoH'
+import syncStarknetState from '$api/src/tasks/syncStarknetState'
 import {db} from 'api/src/lib/db'
 
 /* eslint-disable no-console */
 
 export default async () => {
   try {
-    // await importPoH()
-
     console.log('Seeding unsubmitted profiles')
     await db.unsubmittedProfile.createMany({
       data: [
@@ -46,6 +44,8 @@ export default async () => {
       where: {id: feedback.unsubmittedProfileId},
       data: {unaddressedFeedbackId: feedback.id},
     })
+
+    await syncStarknetState()
 
     // TODO: how are we going to seed actual profiles? Push them to StarkNet first I guess?
     // const pohProfiles = await importPoH()

--- a/redwood/scripts/syncStarknetState.ts
+++ b/redwood/scripts/syncStarknetState.ts
@@ -2,6 +2,5 @@ import syncStarknetState from '$api/src/tasks/syncStarknetState'
 
 export default async ({args}) => {
   console.log('Syncing StarkNet state...')
-  console.log(args)
   await syncStarknetState(!!args.onlyNew)
 }


### PR DESCRIPTION
Don't look up the contents of profile CIDs on Infura every time if they're already stashed in our database.

Also, did this as a new migration since we now have a production deployment. Used `yarn rw prisma migrate dev` for that; quite painless!