### PR TITLE
Notify notaries when a new challenge is submitted

### DIFF
--- a/redwood/api/db/migrations/20220103141407_create_notifications/migration.sql
+++ b/redwood/api/db/migrations/20220103141407_create_notifications/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" SERIAL NOT NULL,
+    "key" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Notification_key_key" ON "Notification"("key");

--- a/redwood/api/db/schema.prisma
+++ b/redwood/api/db/schema.prisma
@@ -120,5 +120,15 @@ model Connection {
   updatedAt DateTime @updatedAt
 
   cachedProfile CachedProfile @relation(fields: [profileId], references: [id])
-  @@unique([ profileId, purposeIdentifier ])
+  @@unique([profileId, purposeIdentifier])
+}
+
+// Track whether we've sent various types of notifications.
+model Notification {
+  id Int @id @default(autoincrement())
+
+  key Json @unique
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/redwood/api/src/services/notifications/notifications.test.ts
+++ b/redwood/api/src/services/notifications/notifications.test.ts
@@ -1,0 +1,39 @@
+import {db} from 'src/lib/db'
+import {maybeNotify} from './notifications'
+
+describe('maybeNotify', () => {
+  test('does not notify if a notification already exists', async () => {
+    const notifyPrevious = jest.fn()
+    await db.notification.create({
+      data: {
+        key: {
+          type: 'NEW_CHALLENGE',
+          profileId: 1,
+          challengeTimestamp: '2022-01-01T00:00:00Z',
+        },
+      },
+    })
+    await maybeNotify(
+      {
+        type: 'NEW_CHALLENGE',
+        challengeTimestamp: '2022-01-01T00:00:00Z',
+        profileId: 1,
+      },
+      notifyPrevious
+    )
+
+    expect(notifyPrevious).not.toHaveBeenCalled()
+
+    const notifyCurrent = jest.fn()
+
+    await maybeNotify(
+      {
+        type: 'NEW_CHALLENGE',
+        challengeTimestamp: '2022-01-02T00:00:00Z',
+        profileId: 1,
+      },
+      notifyCurrent
+    )
+    expect(notifyCurrent).toHaveBeenCalled()
+  })
+})

--- a/redwood/api/src/services/notifications/notifications.ts
+++ b/redwood/api/src/services/notifications/notifications.ts
@@ -1,0 +1,24 @@
+import {db} from 'src/lib/db'
+
+// Add supported notification types here
+type NotificationType = {
+  type: 'NEW_CHALLENGE'
+  profileId: number
+  challengeTimestamp: string
+}
+
+// Only call the provided `notify` function if no existing notification with the
+// same `key` has been created. This prevents us from sending the same
+// notification multiple times.
+
+export const maybeNotify = async (key: NotificationType, notify: Function) => {
+  if ((await db.notification.count({where: {key: {equals: key}}})) > 0) return
+
+  await notify()
+
+  await db.notification.create({
+    data: {
+      key,
+    },
+  })
+}

--- a/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
+++ b/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
@@ -7,7 +7,7 @@ import sendNotaryFeedback from 'src/mailers/sendNotaryFeedback'
 import syncStarknetState from 'src/tasks/syncStarknetState'
 
 // Just hard-code these for now. Will get fancier later.
-const NOTARIES = [
+export const NOTARIES = [
   '+18016131318', // Kyle
   '+16175958777', // Ted
 ]

--- a/redwood/api/src/tasks/syncStarknetState.test.ts
+++ b/redwood/api/src/tasks/syncStarknetState.test.ts
@@ -1,8 +1,15 @@
 import {parseCid} from 'src/lib/serializers'
-import {readCids} from './syncStarknetState'
+import {importProfile, readCids} from './syncStarknetState'
+
+import {exportProfileById} from 'src/lib/starknet'
+import {sendMessage} from 'src/lib/twilio'
+import {db} from 'src/lib/db'
+
+jest.mock('src/lib/starknet')
+jest.mock('src/lib/twilio')
 
 describe('readCids', () => {
-  test('correctly parses a cid', async () => {
+  test.skip('correctly parses a cid', async () => {
     const cid = parseCid(
       '0x0170121be2bfe156987787cd2a79fc49842d0a2143d728f46a28cfd6a31bda'
     )
@@ -10,6 +17,48 @@ describe('readCids', () => {
     expect(await readCids(cid)).toEqual({
       photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
       videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
+    })
+  })
+})
+
+describe('importProfile', () => {
+  test('sends new challenge notifications', async () => {
+    exportProfileById.mockResolvedValueOnce({
+      profile: {
+        cid: '0x170121b909f5bf9672d64c328fb6196c0042b5bac45a7ce829b3a161a186c',
+        ethereum_address: '0x4956f0cd',
+        submitter_address: '0x165dabd',
+        submission_timestamp: '0x929',
+        is_notarized: '0x1',
+        last_recorded_status: '0x1',
+        challenge_timestamp: '0x75bcd15',
+        challenger_address:
+          '0x7283241e75fe4bfa64af202c1243b56e7ab30c7ea41a6e2c6000c5874670dc4',
+        challenge_evidence_cid:
+          '0x170121b6e2ca4f121dea9096755acf32b4caa2d955b1a025b5ff8a8f7fdb6',
+        owner_evidence_cid: '0x0',
+        adjudication_timestamp: '0x0',
+        adjudicator_evidence_cid: '0x0',
+        did_adjudicator_verify_profile: '0x0',
+        appeal_timestamp: '0x0',
+        super_adjudication_timestamp: '0x0',
+        did_super_adjudicator_verify_profile: '0x0',
+      },
+      num_profiles: '0xa',
+      is_verified: '0x0',
+      current_status: '0x1',
+      now: '0x75bcd15',
+    })
+
+    await importProfile(1)
+
+    expect(sendMessage.mock.calls[0][1]).toEqual('New challenge to profile 1')
+
+    const notification = await db.notification.findFirst()
+    expect(notification.key).toEqual({
+      type: 'NEW_CHALLENGE',
+      profileId: 1,
+      challengeTimestamp: '1970-01-02T10:17:36.789Z',
     })
   })
 })


### PR DESCRIPTION
This PR sends a text message to the notaries whenever a new challenge is created.

To ensure notifications are delivered only once, I implemented a "Notification" table and `maybeNotify(key, notificationFunction)` function. 

The function first checks whether a Notification has already been created with the matching key. (I use Postgres's `jsonb` column type, so it shouldn't be sensitive to eg. changing the order of fields.) Assuming no notification has already been created, it calls the `notificationFunction` which is responsible for actually sending the notification.

It works like this:

```js
maybeNotify({ type: 'PROFILE_CREATED', id: 1 }, sendMyNotificationFn)
```

Since we now have a production deployment I also created a new migration for this by running `yarn rw prisma migrate dev`, instead of just resetting the initial migration.