### PR TITLE
Run typechecking on all pull requests

### DIFF
--- a/.github/workflows/redwood-ci.yml
+++ b/.github/workflows/redwood-ci.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+defaults:
+  run:
+    working-directory: ./redwood
+
+jobs:
+  runCI:
+    name: Redwood CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Cache "node_modules"
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules_${{ hashFiles('redwood/**/yarn.lock') }}
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn rw tsc
+      # run: yarn rw test --watch=false --ci
+      # - run: yarn rw lint
+      # - run: yarn rw check


### PR DESCRIPTION
Run `yarn rw tsc` on all pull requests. I'll use follow-up PRs to enable the jest tests and lint, this is more about getting the CI infrastructure set up correctly.