### PR TITLE
Correctly serialize Ethereum addresses

### DIFF
--- a/redwood/api/src/graphql/cachedProfiles.sdl.ts
+++ b/redwood/api/src/graphql/cachedProfiles.sdl.ts
@@ -57,6 +57,7 @@ export const schema = gql`
       @skipAuth
 
     cachedProfile(id: ID!, resync: Boolean = false): CachedProfile @skipAuth
-    cachedProfileByEthAddress(ethereumAddress: ID!): CachedProfile @skipAuth
+    cachedProfileByEthereumAddress(ethereumAddress: ID!): CachedProfile
+      @skipAuth
   }
 `

--- a/redwood/api/src/lib/serializers.test.ts
+++ b/redwood/api/src/lib/serializers.test.ts
@@ -1,22 +1,45 @@
-import {parseAddress} from './serializers'
+import {parseStarknetAddress, parseEthereumAddress} from './serializers'
 
-describe('parseAddress', () => {
+describe('parseStarknetAddress', () => {
   test('parses even-length addresses to a canonical form', () => {
-    expect(parseAddress('0xabcd')).toEqual('0xabcd')
-    expect(parseAddress('0x0abcd')).toEqual('0xabcd')
-    expect(parseAddress('0x00abcd')).toEqual('0xabcd')
-    expect(parseAddress('0x000abcd')).toEqual('0xabcd')
+    expect(parseStarknetAddress('0xabcd')).toEqual('0xabcd')
+    expect(parseStarknetAddress('0x0abcd')).toEqual('0xabcd')
+    expect(parseStarknetAddress('0x00abcd')).toEqual('0xabcd')
+    expect(parseStarknetAddress('0x000abcd')).toEqual('0xabcd')
   })
 
   test('parses odd-length addresses to a canonical form', () => {
-    expect(parseAddress('0xabc')).toEqual('0x0abc')
-    expect(parseAddress('0x0abc')).toEqual('0x0abc')
-    expect(parseAddress('0x00abc')).toEqual('0x0abc')
-    expect(parseAddress('0x000abc')).toEqual('0x0abc')
+    expect(parseStarknetAddress('0xabc')).toEqual('0x0abc')
+    expect(parseStarknetAddress('0x0abc')).toEqual('0x0abc')
+    expect(parseStarknetAddress('0x00abc')).toEqual('0x0abc')
+    expect(parseStarknetAddress('0x000abc')).toEqual('0x0abc')
   })
 
   test('parses a null address', () => {
-    expect(parseAddress('0x0')).toEqual(null)
-    expect(parseAddress(null)).toEqual(null)
+    expect(parseStarknetAddress('0x0')).toEqual(null)
+    expect(parseStarknetAddress(null)).toEqual(null)
+  })
+})
+
+describe('parseEthereumAddress', () => {
+  test('parses addresses to a canonical form', () => {
+    expect(parseEthereumAddress('0xabcd')).toEqual(
+      '0x000000000000000000000000000000000000ABcD'
+    )
+    expect(
+      parseEthereumAddress('0x334230242D318b5CA159fc38E07dC1248B7b35e4')
+    ).toEqual('0x334230242D318b5CA159fc38E07dC1248B7b35e4')
+  })
+
+  test('rejects invalid addresses', () => {
+    // Address can't be more than 40 characters
+    expect(
+      parseEthereumAddress('0x334230242D318b5CA159fc38E07dC1248B7b35e40000')
+    ).toEqual(null)
+  })
+
+  test('parses a null address', () => {
+    expect(parseEthereumAddress('0x0')).toEqual(null)
+    expect(parseEthereumAddress(null)).toEqual(null)
   })
 })

--- a/redwood/api/src/lib/serializers.ts
+++ b/redwood/api/src/lib/serializers.ts
@@ -1,6 +1,7 @@
 import assert from 'minimalistic-assert'
-import {sanitizeHex} from 'starknet/dist/utils/encode'
+import {removeHexPrefix, sanitizeHex} from 'starknet/dist/utils/encode'
 import {CID} from 'ipfs-http-client'
+import {getAddress} from 'ethers/lib/utils'
 
 type Felt = string
 
@@ -34,12 +35,20 @@ export const parseCid = (cid: Felt): CID | null =>
   isInitialized(cid) ? CID.decode(feltToBytes(cid)) : null
 export const serializeCid = (cid: CID) => bytesToFelt(cid.bytes)
 
-export const canonicalizeHex = (hex: string) =>
+const canonicalizeHex = (hex: string) =>
   sanitizeHex(hex.replace(/^0x0*/, '')).toLowerCase()
 
 // Parses an address into an even-length hex string with 0 or 1 leading 0s.
-export const parseAddress = (address: Felt) =>
+export const parseStarknetAddress = (address: Felt) =>
   isInitialized(address) ? canonicalizeHex(address) : null
+
+// Parses an ethereum address into its checksummed form.
+export const parseEthereumAddress = (address: Felt) => {
+  if (!isInitialized(address)) return null
+  if (removeHexPrefix(address).length > 40) return null
+
+  return getAddress(removeHexPrefix(address).padStart(40, '0'))
+}
 
 export const numToHex = (num: number) => '0x' + num.toString(16)
 

--- a/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
+++ b/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
@@ -41,7 +41,7 @@ export const cachedProfile = async ({id, resync}) => {
   return profile
 }
 
-export const cachedProfileByEthAddress = async ({ethereumAddress}) =>
+export const cachedProfileByEthereumAddress = async ({ethereumAddress}) =>
   await db.cachedProfile.findUnique({
     where: {ethereumAddress},
   })

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -2,10 +2,11 @@ import {CachedProfile} from '@prisma/client'
 import {CID} from 'ipfs-http-client'
 import {db} from 'src/lib/db'
 import {
-  parseAddress,
   parseBoolean,
   parseCid,
+  parseEthereumAddress,
   parseNumber,
+  parseStarknetAddress,
   parseTimestamp,
 } from 'src/lib/serializers'
 import {exportProfileById, getNumProfiles} from 'src/lib/starknet'
@@ -32,7 +33,7 @@ export default async function syncStarknetState(onlyNewProfiles = false) {
   currentId = currentId + 1
 
   while (currentId <= maxId) {
-    const {maxId} = await importProfile(currentId)
+    maxId = (await importProfile(currentId)).maxId
 
     currentId = currentId + 1
   }
@@ -59,7 +60,7 @@ export const importProfile = async (profileId: number) => {
     cid: parseCid(profile.cid).toV1().toString(),
     ...(await readCids(parseCid(profile.cid))),
 
-    ethereumAddress: parseAddress(profile.ethereum_address),
+    ethereumAddress: parseEthereumAddress(profile.ethereum_address),
     submissionTimestamp: parseTimestamp(profile.submission_timestamp),
 
     notarized: parseBoolean(profile.is_notarized),
@@ -68,7 +69,7 @@ export const importProfile = async (profileId: number) => {
       parseNumber(profile.last_recorded_status)
     ),
     challengeTimestamp: parseTimestamp(profile.challenge_timestamp),
-    challengerAddress: parseAddress(profile.challenger_address),
+    challengerAddress: parseStarknetAddress(profile.challenger_address),
     challengeEvidenceCid: parseCid(profile.challenge_evidence_cid)
       ?.toV1()
       .toString(),

--- a/redwood/web/src/layouts/UserContext.tsx
+++ b/redwood/web/src/layouts/UserContext.tsx
@@ -5,7 +5,7 @@ import {UserContextQuery, UserContextQueryVariables} from 'types/graphql'
 type UserContextType = {
   ethereumAddress?: string
   unsubmittedProfile?: UserContextQuery['unsubmittedProfile']
-  cachedProfile?: UserContextQuery['cachedProfileByEthAddress']
+  cachedProfile?: UserContextQuery['cachedProfileByEthereumAddress']
 }
 
 const UserContext = React.createContext<UserContextType>({})
@@ -26,7 +26,7 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
           videoCid
         }
 
-        cachedProfileByEthAddress(ethereumAddress: $ethereumAddress) {
+        cachedProfileByEthereumAddress(ethereumAddress: $ethereumAddress) {
           id
           ethereumAddress
         }
@@ -44,7 +44,7 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
   const context: UserContextType = {
     ethereumAddress: ethers.account,
     unsubmittedProfile: data?.unsubmittedProfile,
-    cachedProfile: data?.cachedProfileByEthAddress,
+    cachedProfile: data?.cachedProfileByEthereumAddress,
   }
 
   return <UserContext.Provider value={context}>{children}</UserContext.Provider>


### PR DESCRIPTION
Use the `getAddress` helper from ethers.js, which returns the checksummed version https://github.com/zorro-project/zorro/pull/21#discussion_r778488304.

Also renames `cachedProfileByEthAddress` to `cachedProfileByEthereumAddress` https://github.com/zorro-project/zorro/pull/22#discussion_r778581063.