### PR TITLE
Landing page tweaks

### DIFF
--- a/redwood/web/src/index.html
+++ b/redwood/web/src/index.html
@@ -5,13 +5,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="Zorro: web3 citizenship" />
+  <meta name="og:title" content="Zorro: web3 citizenship" />
   <meta
-    name="twitter:description"
+    name="og:description"
     content="Proof of personhood with fast registration for democratic DAO voting, fair airdrops, etc"
   />
   <meta
-    name="twitter:image"
+    name="og:image"
     content="https://zorro.xyz/logo-twitter-card-square.png"
   />
 </head>

--- a/redwood/web/src/pages/SplashPage/SplashPage.tsx
+++ b/redwood/web/src/pages/SplashPage/SplashPage.tsx
@@ -21,6 +21,7 @@ import {
 import {FaShieldAlt, FaWind, FaVoteYea} from 'react-icons/fa'
 import Nav from './Nav'
 import {Feature} from './Feature'
+import {Helmet, HelmetProvider} from 'react-helmet-async'
 
 const SplashPage = () => {
   return (
@@ -38,6 +39,12 @@ const SplashPage = () => {
 const Hero = () => (
   <>
     <Box maxW={{base: 'xl', md: '5xl'}} mx="auto" px={{base: '6', md: '8'}}>
+      {/* Override the Redwood-managed Helmet provider on this page only to avoid appending " | Zorro" to the title. */}
+      <HelmetProvider>
+        <Helmet>
+          <title>Zorro: web3 citizenship</title>
+        </Helmet>
+      </HelmetProvider>
       <Box textAlign="center">
         <Heading
           as="h1"


### PR DESCRIPTION
1. Use og: tags for cross-platform sharing
2. Change the page title from "Zorro | Zorro" to "Zorro: web3 citizenship"