### PR TITLE
Fix all lint warnings

### DIFF
--- a/redwood/.eslintrc.js
+++ b/redwood/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   rules: {
     'react/no-unescaped-entities': 'off',
     'react-hooks/rules-of-hooks': 'off',
+    'react-hooks/exhaustive-deps': 'off',
   },
 }

--- a/redwood/api/src/lib/starknet.ts
+++ b/redwood/api/src/lib/starknet.ts
@@ -9,7 +9,7 @@ import {
   stark,
 } from 'starknet'
 import {BigNumberish} from 'starknet/dist/utils/number'
-import {bnToUint256, uint256ToBN} from 'starknet/dist/utils/uint256'
+import {bnToUint256, Uint256, uint256ToBN} from 'starknet/dist/utils/uint256'
 import ERC20_ABI from '../../../../starknet/starknet-artifacts/contracts/openzeppelin/ERC20.cairo/ERC20_abi.json'
 import ZORRO_ABI from '../../../../starknet/starknet-artifacts/contracts/zorro.cairo/zorro_abi.json'
 
@@ -101,7 +101,7 @@ export async function erc20GetAllowance(owner: Felt, spender: Felt) {
     spender,
   })
 
-  return uint256ToBN(resp.res as any)
+  return uint256ToBN(resp.res as unknown as Uint256)
 }
 
 export async function erc20GetBalanceOf(owner: Felt) {
@@ -109,7 +109,7 @@ export async function erc20GetBalanceOf(owner: Felt) {
     owner,
   })
 
-  return uint256ToBN(resp.res as any)
+  return uint256ToBN(resp.res as unknown as Uint256)
 }
 
 export async function erc20Mint(
@@ -195,7 +195,7 @@ type Profile = {
 export async function exportProfileById(profileId: number) {
   const profile = (await zorro.call('export_profile_by_id', {
     profile_id: profileId.toString(),
-  })) as any as {
+  })) as unknown as {
     profile: Profile
     num_profiles: Felt
     current_status: Felt

--- a/redwood/api/src/services/notifications/notifications.ts
+++ b/redwood/api/src/services/notifications/notifications.ts
@@ -11,7 +11,10 @@ type NotificationType = {
 // same `key` has been created. This prevents us from sending the same
 // notification multiple times.
 
-export const maybeNotify = async (key: NotificationType, notify: Function) => {
+export const maybeNotify = async (
+  key: NotificationType,
+  notify: () => unknown
+) => {
   if ((await db.notification.count({where: {key: {equals: key}}})) > 0) return
 
   await notify()

--- a/redwood/web/src/components/ConnectButton/AccountModal.tsx
+++ b/redwood/web/src/components/ConnectButton/AccountModal.tsx
@@ -15,8 +15,8 @@ import Identicon from 'src/components/Identicon'
 import UserContext from 'src/layouts/UserContext'
 
 type Props = {
-  isOpen: any
-  onClose: any
+  isOpen: boolean
+  onClose: () => void
 }
 
 export default function AccountModal({isOpen, onClose}: Props) {

--- a/redwood/web/src/components/Identicon.tsx
+++ b/redwood/web/src/components/Identicon.tsx
@@ -18,7 +18,7 @@ const Identicon = ({account, size = 16, ...props}: Props) => {
     }
   }, [ref, account, size])
 
-  return <Box pt="1" {...props} ref={ref as any} />
+  return <Box pt="1" {...props} ref={ref} />
 }
 
 export default Identicon

--- a/redwood/web/src/lib/ipfs.ts
+++ b/redwood/web/src/lib/ipfs.ts
@@ -42,6 +42,6 @@ export const createProfileObject = async (
 ): Promise<CID> => cairoCompatibleAdd(JSON.stringify(components))
 
 // V1 cid to Infura URL
-export const cidToUrl = (cid: String) => `https://${cid}.ipfs.infura-ipfs.io`
+export const cidToUrl = (cid: string) => `https://${cid}.ipfs.infura-ipfs.io`
 
 export default ipfsClient

--- a/redwood/web/src/lib/pusher.ts
+++ b/redwood/web/src/lib/pusher.ts
@@ -8,7 +8,7 @@ const pusher = new Pusher(process.env.PUSHER_KEY, {
 export const usePusher = (
   channel: string,
   event: string,
-  callback: Function
+  callback: () => unknown
 ) => {
   useEffect(() => {
     const pusherChannel = pusher.subscribe(channel)


### PR DESCRIPTION
Disables the "react-hooks/exhaustive-deps" rule as previously discussed, and fixes all other lint warnings.