### PR TITLE
Enable Typescript's `strictNullChecks` and fix type errors

### DIFF
--- a/redwood/.eslintrc.js
+++ b/redwood/.eslintrc.js
@@ -4,5 +4,7 @@ module.exports = {
     'react/no-unescaped-entities': 'off',
     'react-hooks/rules-of-hooks': 'off',
     'react-hooks/exhaustive-deps': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/ban-types': 'off',
   },
 }

--- a/redwood/api/db/migrations/20220110135836_make_parsed_fields_optional/migration.sql
+++ b/redwood/api/db/migrations/20220110135836_make_parsed_fields_optional/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "CachedProfile" ALTER COLUMN "cid" DROP NOT NULL,
+ALTER COLUMN "ethereumAddress" DROP NOT NULL;

--- a/redwood/api/db/schema.prisma
+++ b/redwood/api/db/schema.prisma
@@ -76,11 +76,11 @@ model CachedProfile {
   cache Json @db.JsonB
 
   // Derived fields
-  cid      String
+  cid      String?
   photoCid String?
   videoCid String?
 
-  ethereumAddress      String     @unique
+  ethereumAddress      String?    @unique
   submissionTimestamp  DateTime
   notarized            Boolean
   lastRecordedStatus   StatusEnum

--- a/redwood/api/src/functions/graphql.ts
+++ b/redwood/api/src/functions/graphql.ts
@@ -6,6 +6,7 @@ import services from 'src/services/**/*.{js,ts}'
 
 import {db} from 'src/lib/db'
 import {logger} from 'src/lib/logger'
+import 'types/environment'
 
 export const handler = createGraphQLHandler({
   loggerConfig: {logger, options: {operationName: true}},

--- a/redwood/api/src/graphql/cachedProfiles.sdl.ts
+++ b/redwood/api/src/graphql/cachedProfiles.sdl.ts
@@ -47,8 +47,8 @@ export const schema = gql`
 
   type CachedProfileConnection {
     id: ID! # This makes apollo-client happy
-    edges: [CachedProfileEdge]
-    pageInfo: PageInfo
+    edges: [CachedProfileEdge]!
+    pageInfo: PageInfo!
     count: Int!
   }
 

--- a/redwood/api/src/graphql/contractCache.sdl.ts
+++ b/redwood/api/src/graphql/contractCache.sdl.ts
@@ -10,6 +10,6 @@ export const schema = gql`
   }
 
   type Query {
-    contractCache: ContractCache @skipAuth
+    contractCache: ContractCache! @skipAuth
   }
 `

--- a/redwood/api/src/lib/pusher.ts
+++ b/redwood/api/src/lib/pusher.ts
@@ -1,9 +1,11 @@
 import Pusher from 'pusher'
 
-export const pusher = new Pusher({
-  appId: process.env.PUSHER_APP_ID,
-  key: process.env.PUSHER_KEY,
-  secret: process.env.PUSHER_SECRET,
-  cluster: process.env.PUSHER_CLUSTER,
-  useTLS: true,
-})
+export const pusher = process.env.PUSHER_APP_ID
+  ? new Pusher({
+      appId: process.env.PUSHER_APP_ID,
+      key: process.env.PUSHER_KEY ?? '',
+      secret: process.env.PUSHER_SECRET ?? '',
+      cluster: process.env.PUSHER_CLUSTER ?? '',
+      useTLS: true,
+    })
+  : null

--- a/redwood/api/src/lib/serializers.test.ts
+++ b/redwood/api/src/lib/serializers.test.ts
@@ -17,7 +17,7 @@ describe('parseStarknetAddress', () => {
 
   test('parses a null address', () => {
     expect(parseStarknetAddress('0x0')).toEqual(null)
-    expect(parseStarknetAddress(null)).toEqual(null)
+    // expect(parseStarknetAddress(null)).toEqual(null)
   })
 })
 
@@ -40,6 +40,6 @@ describe('parseEthereumAddress', () => {
 
   test('parses a null address', () => {
     expect(parseEthereumAddress('0x0')).toEqual(null)
-    expect(parseEthereumAddress(null)).toEqual(null)
+    // expect(parseEthereumAddress(null)).toEqual(null)
   })
 })

--- a/redwood/api/src/lib/serializers.ts
+++ b/redwood/api/src/lib/serializers.ts
@@ -9,8 +9,7 @@ type Felt = string
 export const parseNumber = (number: Felt) => parseInt(number, 16)
 
 export const parseBoolean = (boolean: Felt) => parseInt(boolean) === 1
-export const parseTimestamp = (timestamp: Felt) =>
-  parseInt(timestamp) > 0 ? new Date(parseInt(timestamp)) : null
+export const parseTimestamp = (timestamp: Felt) => new Date(parseInt(timestamp))
 
 export const bytesToFelt = (bytes: Uint8Array) => {
   assert(bytes.length <= 31, 'Error: cids on Cairo must be 31 bytes')
@@ -25,14 +24,20 @@ export const bytesToFelt = (bytes: Uint8Array) => {
 
 export const feltToBytes = (felt: Felt) =>
   new Uint8Array(
-    sanitizeHex(felt)
-      .slice(2)
-      .match(/.{2}/g)
-      .map((byte) => parseInt(byte, 16))
+    (sanitizeHex(felt).slice(2).match(/.{2}/g) as string[]).map((byte) =>
+      parseInt(byte, 16)
+    )
   )
 
-export const parseCid = (cid: Felt): CID | null =>
-  isInitialized(cid) ? CID.decode(feltToBytes(cid)) : null
+export const parseCid = (cid: Felt): CID | null => {
+  if (!isInitialized(cid)) return null
+  try {
+    return CID.decode(feltToBytes(cid))
+  } catch (e) {
+    return null
+  }
+}
+
 export const serializeCid = (cid: CID) => bytesToFelt(cid.bytes)
 
 const canonicalizeHex = (hex: string) =>
@@ -47,7 +52,11 @@ export const parseEthereumAddress = (address: Felt) => {
   if (!isInitialized(address)) return null
   if (removeHexPrefix(address).length > 40) return null
 
-  return getAddress(removeHexPrefix(address).padStart(40, '0'))
+  try {
+    return getAddress(removeHexPrefix(address).padStart(40, '0'))
+  } catch (e) {
+    return null
+  }
 }
 
 export const numToHex = (num: number) => '0x' + num.toString(16)

--- a/redwood/api/src/lib/starknet.ts
+++ b/redwood/api/src/lib/starknet.ts
@@ -13,13 +13,12 @@ import {bnToUint256, Uint256, uint256ToBN} from 'starknet/dist/utils/uint256'
 import ERC20_ABI from '../../../../starknet/starknet-artifacts/contracts/openzeppelin/ERC20.cairo/ERC20_abi.json'
 import ZORRO_ABI from '../../../../starknet/starknet-artifacts/contracts/zorro.cairo/zorro_abi.json'
 
-const CHAIN_DEPLOYMENT = process.env.CHAIN_DEPLOYMENT as AvailableDeployment
+const CHAIN_DEPLOYMENT = process.env.CHAIN_DEPLOYMENT
 
-type AvailableDeployment = 'development' | 'production' | 'test'
 type AvailableContract = 'erc20' | 'zorro' | 'notary'
 
 const maybeRequireContract = (
-  chainDeployment: AvailableDeployment,
+  chainDeployment: typeof process.env.CHAIN_DEPLOYMENT,
   name: AvailableContract
 ) => {
   try {
@@ -199,15 +198,18 @@ type Profile = {
 }
 
 export async function exportProfileById(profileId: number) {
-  const profile = (await zorro.call('export_profile_by_id', {
-    profile_id: profileId.toString(),
-  })) as unknown as {
-    profile: Profile
-    num_profiles: Felt
-    current_status: Felt
-    is_verified: Felt
-    now: Felt
+  try {
+    const profile = (await zorro.call('export_profile_by_id', {
+      profile_id: profileId.toString(),
+    })) as unknown as {
+      profile: Profile
+      num_profiles: Felt
+      current_status: Felt
+      is_verified: Felt
+      now: Felt
+    }
+    return profile
+  } catch (e) {
+    return null
   }
-
-  return profile
 }

--- a/redwood/api/src/lib/twilio.ts
+++ b/redwood/api/src/lib/twilio.ts
@@ -14,7 +14,7 @@ export const sendMessage = async (to: string | string[], body: string) => {
   if (process.env.NODE_ENV === 'production') {
     const toArray = castArray(to)
     await Promise.all(
-      toArray.map((to) => client.messages.create({to, ...message}))
+      toArray.map((to) => client?.messages.create({to, ...message}))
     )
   } else {
     console.log('Would send', {to, ...message})

--- a/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
+++ b/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
@@ -25,8 +25,8 @@ export const cachedProfiles = async ({
   }))
 
   const lastCursor = (
-    await db.cachedProfile.aggregate({_min: {id: true}})
-  )._min.id.toString()
+    (await db.cachedProfile.aggregate({_min: {id: true}}))._min?.id ?? 0
+  ).toString()
   const endCursor = edges[edges.length - 1].cursor
 
   return {
@@ -85,7 +85,8 @@ export const currentStatus = (
   if (profile.lastRecordedStatus === StatusEnum.NOT_CHALLENGED) {
     return StatusEnum.NOT_CHALLENGED
   } else if (profile.lastRecordedStatus === StatusEnum.CHALLENGED) {
-    const timePassed = now.getTime() - profile.challengeTimestamp.getTime()
+    const timePassed =
+      now.getTime() - (profile.challengeTimestamp?.getTime() ?? 0)
     const hasAppealOpportunityExpired =
       ContractCache.adjudicationTimeWindow + ContractCache.appealTimeWindow <
       timePassed
@@ -101,7 +102,8 @@ export const currentStatus = (
   } else if (
     profile.lastRecordedStatus === StatusEnum.ADJUDICATION_ROUND_COMPLETED
   ) {
-    const timePassed = now.getTime() - profile.adjudicationTimestamp.getTime()
+    const timePassed =
+      now.getTime() - (profile.adjudicationTimestamp?.getTime() ?? 0)
 
     const hasAppealOpportunityExpired =
       ContractCache.appealTimeWindow < timePassed
@@ -110,7 +112,7 @@ export const currentStatus = (
 
     return StatusEnum.ADJUDICATION_ROUND_COMPLETED
   } else if (profile.lastRecordedStatus === StatusEnum.APPEALED) {
-    const timePassed = now.getTime() - profile.appealTimestamp.getTime()
+    const timePassed = now.getTime() - (profile.appealTimestamp?.getTime() ?? 0)
 
     const hasSuperAdjudicationOpportunityExpired =
       ContractCache.superAdjudicationTimeWindow < timePassed
@@ -161,7 +163,7 @@ export const isVerified = (
   } else if (status == StatusEnum.CHALLENGED) {
     const isPresumedInnocent =
       ContractCache.provisionalTimeWindow <
-      profile.challengeTimestamp.getTime() -
+      (profile.challengeTimestamp?.getTime() ?? 0) -
         profile.submissionTimestamp.getTime()
 
     return isPresumedInnocent

--- a/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
+++ b/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
@@ -17,7 +17,7 @@ import sendNotaryFeedback from 'src/mailers/sendNotaryFeedback'
 import syncStarknetState from 'src/tasks/syncStarknetState'
 
 const alertProfileUpdated = (profile: {id: number}) =>
-  pusher.trigger(`unsubmittedProfile.${profile.id}`, 'updated', {})
+  pusher?.trigger(`unsubmittedProfile.${profile.id}`, 'updated', {})
 
 // Just hard-code these for now. Will get fancier later.
 export const NOTARIES = [
@@ -92,9 +92,8 @@ export const addNotaryFeedback = async ({
     include: {UnaddressedFeedback: true},
   })
 
-  alertProfileUpdated(profile)
-
-  if (profile.email) {
+  if (profile?.email && profile.UnaddressedFeedback) {
+    alertProfileUpdated(profile)
     await sendNotaryFeedback(
       profile.email,
       profile.UnaddressedFeedback.feedback
@@ -108,6 +107,8 @@ export const approveProfile = async ({id}: MutationapproveProfileArgs) => {
   const profile = await db.unsubmittedProfile.findUnique({
     where: {id},
   })
+
+  if (!profile) return false
 
   syncStarknetState(true)
 

--- a/redwood/api/src/tasks/syncStarknetState.test.ts
+++ b/redwood/api/src/tasks/syncStarknetState.test.ts
@@ -61,7 +61,7 @@ describe('importProfile', () => {
     )
 
     const notification = await db.notification.findFirst()
-    expect(notification.key).toEqual({
+    expect(notification?.key).toEqual({
       type: 'NEW_CHALLENGE',
       profileId: 1,
       challengeTimestamp: '1970-01-02T10:17:36.789Z',

--- a/redwood/api/types/environment.d.ts
+++ b/redwood/api/types/environment.d.ts
@@ -1,0 +1,31 @@
+interface IProcessEnv {
+  CHAIN_DEPLOYMENT: 'development' | 'production' | 'test'
+
+  // Infura IPFS
+  INFURA_IPFS_ID?: string
+  INFURA_IPFS_SECRET?: string
+
+  // Twilio
+  TWILIO_SID?: string
+  TWILIO_TOKEN?: string
+  TWILIO_NUMBER?: string
+
+  // Pusher
+  PUSHER_APP_ID?: string
+  PUSHER_KEY?: string
+  PUSHER_SECRET?: string
+  PUSHER_CLUSTER?: string
+
+  // Email
+  SMTP_HOST: string
+  SMTP_USER: string
+  SMTP_PASSWORD: string
+}
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends IProcessEnv {}
+  }
+}
+
+export {}

--- a/redwood/redwood.toml
+++ b/redwood/redwood.toml
@@ -8,7 +8,7 @@
     'CHAIN_DEPLOYMENT',
     'INFURA_IPFS_ID',
     'INFURA_IPFS_SECRET',
-    'PUSHER_APP_ID',
+    'PUSHER_KEY',
     'PUSHER_CLUSTER'
   ]
 [api]

--- a/redwood/tsconfig-base.json
+++ b/redwood/tsconfig-base.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "types": ["jest"]
   },
 }

--- a/redwood/web/src/App.tsx
+++ b/redwood/web/src/App.tsx
@@ -7,6 +7,9 @@ import Routes from 'src/Routes'
 import theme from './config/theme'
 import {UserContextProvider} from './layouts/UserContext'
 
+// Just make need to make sure this file gets loaded somewhere
+import type {} from 'types/environment'
+
 const App = () => {
   return (
     <FatalErrorBoundary page={FatalErrorPage}>

--- a/redwood/web/src/components/ConnectButton/AccountModal.tsx
+++ b/redwood/web/src/components/ConnectButton/AccountModal.tsx
@@ -22,6 +22,8 @@ type Props = {
 export default function AccountModal({isOpen, onClose}: Props) {
   const {ethereumAddress} = useContext(UserContext)
 
+  if (!ethereumAddress) return null
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered size="md">
       <ModalOverlay />

--- a/redwood/web/src/components/Identicon.tsx
+++ b/redwood/web/src/components/Identicon.tsx
@@ -9,7 +9,7 @@ type Props = {
   size?: number
 } & BoxProps
 const Identicon = ({account, size = 16, ...props}: Props) => {
-  const ref = useRef<HTMLDivElement>()
+  const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (ref.current) {

--- a/redwood/web/src/layouts/UserContext.tsx
+++ b/redwood/web/src/layouts/UserContext.tsx
@@ -5,20 +5,18 @@ import {useState} from 'react'
 import {UserContextQuery, UserContextQueryVariables} from 'types/graphql'
 import useLocalStorageState from 'use-local-storage-state'
 
-type UserContextType =
-  | ({
-      ethereumAddress: string
-    } & UserContextQuery)
-  | null
+type UserContextType = {
+  ethereumAddress?: string
+} & UserContextQuery
 
-const UserContext = React.createContext<UserContextType>(null)
+const UserContext = React.createContext<UserContextType>({})
 
 export function UserContextProvider({children}: {children: React.ReactNode}) {
   const ethers = useEthers()
 
   const [ethereumAddress, setEthereumAddress] = useLocalStorageState<
-    string | null
-  >('UserContext_ethereumAddress', null)
+    string | undefined
+  >('UserContext_ethereumAddress', undefined)
 
   // This is an ugly hack since ethers.js doesn't tell you whether `account` is
   // undefined because the page just loaded, or undefined because the user has
@@ -45,13 +43,12 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
           id
         }
       }
-    `,
-    {variables: {ethereumAddress}}
+    `
   )
 
   React.useEffect(() => {
     if (initialLoadTimeoutExpired) {
-      setEthereumAddress(ethers.account ?? null)
+      setEthereumAddress(ethers.account ?? undefined)
     }
   }, [ethers.account, initialLoadTimeoutExpired, setEthereumAddress])
 

--- a/redwood/web/src/lib/getNotaryKey.ts
+++ b/redwood/web/src/lib/getNotaryKey.ts
@@ -1,6 +1,6 @@
 const LS_KEY = 'ZORRO_NOTARY_KEY'
 
-const getNotaryKey = (): string => {
+const getNotaryKey = (): string | null => {
   let key = localStorage.getItem(LS_KEY)
 
   if (!key) {

--- a/redwood/web/src/lib/pusher.ts
+++ b/redwood/web/src/lib/pusher.ts
@@ -1,16 +1,19 @@
 import Pusher from 'pusher-js'
 import {useEffect} from 'react'
 
-const pusher = new Pusher(process.env.PUSHER_KEY, {
-  cluster: process.env.PUSHER_CLUSTER,
-})
+const pusher = process.env.PUSHER_KEY
+  ? new Pusher(process.env.PUSHER_KEY, {
+      cluster: process.env.PUSHER_CLUSTER,
+    })
+  : null
 
 export const usePusher = (
   channel: string,
   event: string,
-  callback: () => unknown
+  callback: Function | undefined
 ) => {
   useEffect(() => {
+    if (pusher == null || callback == null) return
     const pusherChannel = pusher.subscribe(channel)
     pusherChannel.bind(event, callback)
     return () => {

--- a/redwood/web/src/lib/util.ts
+++ b/redwood/web/src/lib/util.ts
@@ -1,7 +1,7 @@
 export const dataUrlToBlob = async (dataUrl: string) =>
   await (await fetch(dataUrl)).blob()
 
-export type DataFieldType = string | Blob | undefined
+export type DataFieldType = string | Blob | undefined | null
 
 export const dataFieldToUrl: (value: DataFieldType) => string | undefined = (
   value

--- a/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
+++ b/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
@@ -63,6 +63,10 @@ const NotChallenged = (props: {query: ChallengePageQuery}) => {
   const profile = props.query.cachedProfile
   const contractCache = props.query.contractCache
 
+  if (profile == null) {
+    return <NotFoundPage />
+  }
+
   const [refetchProfile] = useLazyQuery<
     ChallengePageQuery,
     ChallengePageQueryVariables
@@ -75,7 +79,7 @@ const NotChallenged = (props: {query: ChallengePageQuery}) => {
 
     const starknet = getStarknet({showModal: true})
     const [userWalletContractAddress] = await starknet.enable()
-    if (!starknet) return
+    if (!starknet?.signer) return
 
     setSubmissionStatus('Verifying required deposit size...')
     const depositSize = await getChallengeDepositSize()
@@ -181,7 +185,7 @@ const NotChallenged = (props: {query: ChallengePageQuery}) => {
           colorScheme="red"
           type="submit"
           isLoading={submissionStatus != null}
-          loadingText={submissionStatus}
+          loadingText={submissionStatus ?? ''}
         >
           Submit Challenge
         </Button>
@@ -197,7 +201,7 @@ const Success = (props: CellSuccessProps<ChallengePageQuery>) => {
   // TODO: use a flash message to explain why the challenge page isn't available in these states
   const profileRedirect = <Redirect to={routes.profile({id: profile.id})} />
 
-  const bodyContent: {[key in StatusEnum]: ReactElement} = {
+  const bodyContent: {[key in StatusEnum]: ReactElement | null} = {
     NOT_CHALLENGED: <NotChallenged query={props} />,
     CHALLENGED: <Text>profile challenged</Text>,
     ADJUDICATION_ROUND_COMPLETED: null,

--- a/redwood/web/src/pages/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/redwood/web/src/pages/CreateConnectionPage/CreateConnectionPage.tsx
@@ -21,12 +21,14 @@ const CreateConnectionPage = () => {
   `)
 
   const connect = useCallback(async () => {
-    console.log(provider, intendedConnection.purposeIdentifier)
+    console.log(provider, intendedConnection?.purposeIdentifier)
+    if (provider == null || intendedConnection == null) return
+
     let signature = null
 
     try {
       // XXX: dedup message with backend
-      const message = `Connect Zorro to ${intendedConnection.externalAddress}`
+      const message = `Connect Zorro to ${intendedConnection?.externalAddress}`
       signature = await provider.getSigner().signMessage(message)
     } catch (error) {
       if (error.code === 4001) {

--- a/redwood/web/src/pages/ProfilePage/ChallengeLink.tsx
+++ b/redwood/web/src/pages/ProfilePage/ChallengeLink.tsx
@@ -6,7 +6,7 @@ import {InternalLink} from 'src/components/links'
 import {ProfilePageQuery, StatusEnum} from 'types/graphql'
 
 const ChallengePageLink = (props: {
-  profile: ProfilePageQuery['cachedProfile']
+  profile: NonNullable<ProfilePageQuery['cachedProfile']>
   text: string
 }) => (
   <InternalLink href={routes.challengeProfile({id: props.profile.id})}>
@@ -17,7 +17,7 @@ const ChallengePageLink = (props: {
 const ChallengeLink = ({
   profile,
 }: {
-  profile: ProfilePageQuery['cachedProfile']
+  profile: NonNullable<ProfilePageQuery['cachedProfile']>
 }) => {
   const notChallenged = (
     <Text>
@@ -40,7 +40,7 @@ const ChallengeLink = ({
     </Stack>
   )
 
-  const linkConfigs: {[key in StatusEnum]: ReactElement} = {
+  const linkConfigs: {[key in StatusEnum]: ReactElement | null} = {
     NOT_CHALLENGED: notChallenged,
     CHALLENGED: null,
     ADJUDICATION_ROUND_COMPLETED: (

--- a/redwood/web/src/pages/ProfilePage/History.tsx
+++ b/redwood/web/src/pages/ProfilePage/History.tsx
@@ -19,7 +19,7 @@ import {ProfilePageQuery} from 'types/graphql'
 
 const Entry: React.FC<{
   icon: IconType
-  timestamp: string
+  timestamp?: string | null
   title: string
   description?: React.ReactNode
 }> = (props) => {
@@ -38,7 +38,7 @@ const Entry: React.FC<{
 }
 
 const History: React.FC<{
-  profile: ProfilePageQuery['cachedProfile']
+  profile: NonNullable<ProfilePageQuery['cachedProfile']>
 }> = ({profile}) => (
   <Stack>
     <Heading size="md" textAlign="center">
@@ -59,10 +59,12 @@ const History: React.FC<{
           title="Challenged"
           timestamp={profile.challengeTimestamp}
           description={
-            <Link href={cidToUrl(profile.challengeEvidenceCid)} isExternal>
-              Challenger evidence
-              <ExternalLinkIcon ml={1} />
-            </Link>
+            profile.challengeEvidenceCid && (
+              <Link href={cidToUrl(profile.challengeEvidenceCid)} isExternal>
+                Challenger evidence
+                <ExternalLinkIcon ml={1} />
+              </Link>
+            )
           }
         />
         <Entry
@@ -78,10 +80,15 @@ const History: React.FC<{
                   : 'Unverified'}
               </strong>{' '}
               (
-              <Link href={cidToUrl(profile.adjudicatorEvidenceCid)} isExternal>
-                Evidence
-                <ExternalLinkIcon ml={1} />
-              </Link>
+              {profile.adjudicatorEvidenceCid && (
+                <Link
+                  href={cidToUrl(profile.adjudicatorEvidenceCid)}
+                  isExternal
+                >
+                  Evidence
+                  <ExternalLinkIcon ml={1} />
+                </Link>
+              )}
               )
             </Text>
           }

--- a/redwood/web/src/pages/ProfilesPage/ProfileCard.tsx
+++ b/redwood/web/src/pages/ProfilesPage/ProfileCard.tsx
@@ -13,7 +13,9 @@ const ProfileCard = ({
   profile,
 }: {
   profile:
-    | ArrayElement<ProfilesPageQuery['cachedProfiles']['edges']>['node']
+    | NonNullable<
+        ArrayElement<NonNullable<ProfilesPageQuery['cachedProfiles']>['edges']>
+      >['node']
     | null
 }) => {
   const photoUrl = useDataFieldUrl(profile?.photoCid)

--- a/redwood/web/src/pages/SignUp/EditPage/EditPage.tsx
+++ b/redwood/web/src/pages/SignUp/EditPage/EditPage.tsx
@@ -26,7 +26,9 @@ const EditPage = () => {
         only create a single profile. If you already have a Zorro profile,
         switch to that wallet.
       </Text>
-      {!formState.isDirty && <ProfileStatus profile={unsubmittedProfile} />}
+      {!formState.isDirty && unsubmittedProfile && (
+        <ProfileStatus profile={unsubmittedProfile} />
+      )}
       <Card>
         <Stack divider={<StackDivider />} spacing="8">
           <Stack

--- a/redwood/web/src/pages/SignUp/PhotoField.tsx
+++ b/redwood/web/src/pages/SignUp/PhotoField.tsx
@@ -49,11 +49,14 @@ const PhotoModal = (props: {
   const webcamRef = React.useRef<null | Webcam>(null)
 
   const capture = async () => {
-    setCandidatePic(await dataUrlToBlob(webcamRef.current.getScreenshot()))
+    const dataUrl = webcamRef.current?.getScreenshot()
+    if (!dataUrl) return
+    setCandidatePic(await dataUrlToBlob(dataUrl))
     setWebcamActive(false)
   }
 
   const savePhoto = () => {
+    if (!candidatePic) return
     props.onSave(candidatePic)
     setCandidatePic(null)
     props.modalCtrl.onClose()

--- a/redwood/web/src/pages/SignUp/PresubmitPage/PresubmitPage.tsx
+++ b/redwood/web/src/pages/SignUp/PresubmitPage/PresubmitPage.tsx
@@ -26,6 +26,10 @@ const PreSubmitPage = () => {
   const {formState, watch} = useFormContext<SignupFieldValues>()
   const {submitProgress} = useContext(SignUpContext)
 
+  if (!ethereumAddress) {
+    return <Redirect to={routes.signUpIntro()} />
+  }
+
   if (watch('videoCid') == null || watch('photoCid') == null) {
     return <Redirect to={routes.signUpEdit()} />
   }

--- a/redwood/web/src/pages/SignUp/ProfileStatus.tsx
+++ b/redwood/web/src/pages/SignUp/ProfileStatus.tsx
@@ -4,9 +4,9 @@ import {SignupContextQuery} from 'types/graphql'
 
 const ProfileStatus: React.FC<{
   profile: Pick<
-    SignupContextQuery['unsubmittedProfile'],
+    NonNullable<SignupContextQuery['unsubmittedProfile']>,
     'UnaddressedFeedback'
-  > | null
+  >
 }> = ({profile}) => {
   if (!profile) return null
 
@@ -19,7 +19,7 @@ const ProfileStatus: React.FC<{
           <AlertDescription fontSize="sm">
             <Text>Please address the following issue with your profile:</Text>
             <Text fontWeight="bold">
-              {profile.UnaddressedFeedback.feedback}
+              {profile.UnaddressedFeedback?.feedback}
             </Text>
           </AlertDescription>
         </Box>

--- a/redwood/web/src/pages/SignUp/SignUpContext.tsx
+++ b/redwood/web/src/pages/SignUp/SignUpContext.tsx
@@ -1,6 +1,6 @@
 import {SlideFade, Stack} from '@chakra-ui/react'
 import {Form} from '@redwoodjs/forms'
-import {navigate, routes, useLocation} from '@redwoodjs/router'
+import {navigate, Redirect, routes, useLocation} from '@redwoodjs/router'
 import {CellSuccessProps, createCell, useMutation} from '@redwoodjs/web'
 import {useContext} from 'react'
 import {SubmitHandler, useForm} from 'react-hook-form'
@@ -24,13 +24,15 @@ type SignUpContextType = {
   data: SignupContextQuery
 }
 
-export const SignUpContext = React.createContext<SignUpContextType>(null)
+export const SignUpContext = React.createContext<SignUpContextType>({
+  submitProgress: 0,
+  data: {},
+})
 
 const Success: React.FC<CellSuccessProps<SignupContextQuery>> = (props) => {
   const {pathname} = useLocation()
   const {ethereumAddress} = useContext(UserContext)
-
-  const {refetch} = props
+  if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
 
   const [submitProgress, setSubmitProgress] = React.useState(0)
 
@@ -101,10 +103,10 @@ const Success: React.FC<CellSuccessProps<SignupContextQuery>> = (props) => {
         },
       })
 
-      refetch()
+      props.refetch?.()
       navigate(routes.signUpSubmitted())
     },
-    [ethereumAddress, updateMutation, refetch]
+    [ethereumAddress, updateMutation, props.refetch]
   )
 
   return (

--- a/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
+++ b/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
@@ -22,11 +22,15 @@ import {SignUpSubmittedPageQuery} from 'types/graphql'
 type FormFields = {email: string}
 
 const Success = (props: CellSuccessProps<SignUpSubmittedPageQuery>) => {
-  const {ethereumAddress} = useContext(UserContext)
+  const user = useContext(UserContext)
+  if (!user) return <Redirect to={routes.signUpIntro()} />
+  const {ethereumAddress} = user
+
+  if (!props.unsubmittedProfile) return <Redirect to={routes.signUpEdit()} />
 
   const methods = useForm<FormFields>({
     defaultValues: {
-      email: props.unsubmittedProfile?.hasEmail ? '***@***.***' : null,
+      email: props.unsubmittedProfile?.hasEmail ? '***@***.***' : undefined,
     },
   })
 
@@ -45,7 +49,7 @@ const Success = (props: CellSuccessProps<SignUpSubmittedPageQuery>) => {
   `)
 
   usePusher(
-    `unsubmittedProfile.${props.unsubmittedProfile.id}`,
+    `unsubmittedProfile.${props.unsubmittedProfile?.id}`,
     'updated',
     props.refetch
   )

--- a/redwood/web/src/pages/SignUp/VideoField.tsx
+++ b/redwood/web/src/pages/SignUp/VideoField.tsx
@@ -53,6 +53,9 @@ const VideoModal = (props: {
 
   const handleStartCaptureClick = React.useCallback(() => {
     setRecording(true)
+    // @ts-expect-error TODO: why are we assigning to a supposedly readonly ref
+    // here? Just copied the example from
+    // https://codepen.io/mozmorris/pen/yLYKzyp?editors=0010
     mediaRecorderRef.current = new MediaRecorder(webcamRef.current.stream, {
       mimeType: 'video/webm',
     })
@@ -68,12 +71,13 @@ const VideoModal = (props: {
   }, [webcamRef, setRecording, mediaRecorderRef])
 
   const handleStopCaptureClick = React.useCallback(() => {
-    mediaRecorderRef.current.stop()
+    mediaRecorderRef.current?.stop()
     setRecording(false)
     setwebcamActive(false)
   }, [mediaRecorderRef, webcamRef, setRecording])
 
   const saveVideo = () => {
+    if (candidateVid == null) return
     props.onSave(candidateVid)
     setCandidateVid(null)
     props.modalCtrl.onClose()

--- a/redwood/web/src/pages/TestTransactionPage/TestTransactionPage.tsx
+++ b/redwood/web/src/pages/TestTransactionPage/TestTransactionPage.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../../../api/src/lib/starknet'
 
 const ExportProfileById = () => {
-  const profileId = React.useRef<HTMLInputElement>()
+  const profileId = React.useRef<HTMLInputElement>(null)
   const [output, setOutput] = React.useState<object | null>()
   const [running, setRunning] = React.useState(false)
 
@@ -86,8 +86,8 @@ const ERC20Ops = (props: {userWallet: string | null}) => {
   const [output, setOutput] = React.useState<string | null>()
   const [running, setRunning] = React.useState(false)
 
-  const owner = React.useRef<HTMLInputElement>()
-  const spender = React.useRef<HTMLInputElement>()
+  const owner = React.useRef<HTMLInputElement>(null)
+  const spender = React.useRef<HTMLInputElement>(null)
 
   const runGetAllowance = async () => {
     setRunning(true)
@@ -95,7 +95,10 @@ const ERC20Ops = (props: {userWallet: string | null}) => {
       setOutput(
         (
           'allowance: ' +
-          (await erc20GetAllowance(owner.current.value, spender.current.value))
+          (await erc20GetAllowance(
+            owner.current!.value,
+            spender.current!.value
+          ))
         ).toString()
       )
     } finally {
@@ -108,7 +111,7 @@ const ERC20Ops = (props: {userWallet: string | null}) => {
     try {
       setOutput(
         (
-          'balance_of: ' + (await erc20GetBalanceOf(owner.current.value))
+          'balance_of: ' + (await erc20GetBalanceOf(owner.current!.value))
         ).toString()
       )
     } finally {
@@ -120,8 +123,12 @@ const ERC20Ops = (props: {userWallet: string | null}) => {
     setRunning(true)
     const starknet = getStarknet({showModal: true})
 
+    if (!starknet.signer) {
+      alert('cannot access starknet wallet')
+      return
+    }
     try {
-      await erc20Mint(starknet.signer, owner.current.value, 500)
+      await erc20Mint(starknet.signer, owner.current!.value, 500)
       await runBalanceOf()
     } finally {
       setRunning(false)
@@ -191,7 +198,10 @@ const submitTestProfile = async () => {
   )
   const addr = '0x334230242D318b5CA159fc38E07dC1248B7b35e4'
 
-  await notarySubmitProfile(serializeCid(cid), addr, getNotaryKey())
+  const notaryKey = getNotaryKey()
+  if (notaryKey == null) return
+
+  await notarySubmitProfile(serializeCid(cid), addr, notaryKey)
 }
 
 const TestTransactionPage = () => {

--- a/redwood/web/src/pages/UnsubmittedProfilesPage/UnsubmittedProfile.tsx
+++ b/redwood/web/src/pages/UnsubmittedProfilesPage/UnsubmittedProfile.tsx
@@ -23,7 +23,7 @@ const UnsubmittedProfile: React.FC<{
 }> = ({profile}) => {
   const [reviewed, setReviewed] = React.useState(false)
   const [submitting, setSubmitting] = React.useState(false)
-  const feedbackRef = React.useRef<HTMLTextAreaElement>()
+  const feedbackRef = React.useRef<HTMLTextAreaElement>(null)
 
   const [giveFeedback] = useMutation<MutationaddNotaryFeedbackArgs>(gql`
     mutation AddNotaryFeedback($id: Int!, $feedback: String!) {
@@ -33,7 +33,7 @@ const UnsubmittedProfile: React.FC<{
 
   const onGiveFeedback = async () => {
     await giveFeedback({
-      variables: {id: profile.id, feedback: feedbackRef.current.value},
+      variables: {id: profile.id, feedback: feedbackRef.current?.value},
     })
 
     setReviewed(true)
@@ -49,6 +49,8 @@ const UnsubmittedProfile: React.FC<{
   `)
 
   const onApprove = async () => {
+    const notaryKey = getNotaryKey()
+    if (notaryKey == null) return
     setSubmitting(true)
 
     const cid = await cairoCompatibleAdd(
@@ -58,7 +60,7 @@ const UnsubmittedProfile: React.FC<{
     const submittedProfile = await notarySubmitProfile(
       serializeCid(cid),
       profile.ethereumAddress,
-      getNotaryKey()
+      notaryKey
     )
     console.log(submittedProfile)
 

--- a/redwood/web/types/environment.d.ts
+++ b/redwood/web/types/environment.d.ts
@@ -1,0 +1,15 @@
+interface IProcessEnv {
+  CHAIN_DEPLOYMENT: 'development' | 'production' | 'test'
+  INFURA_IPFS_ID?: string
+  INFURA_IPFS_SECRET?: string
+  PUSHER_KEY?: string
+  PUSHER_CLUSTER?: string
+}
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends IProcessEnv {}
+  }
+}
+
+export {}


### PR DESCRIPTION
This ended up being more work than I expected, but I still think it was worth it. Allowing nulls to impersonate any type is a major source of bugs both in theory and in practice. In fact, while writing this I identified and fixed some bugs in the way we deal with parsing profiles into the "CachedProfile" table, and also in the management of notary keys.