### PR TITLE
Forward the ref for RLinks

### DIFF
--- a/redwood/web/src/components/links.tsx
+++ b/redwood/web/src/components/links.tsx
@@ -7,10 +7,10 @@ import {
 } from '@chakra-ui/react'
 import {Link as RedwoodLink} from '@redwoodjs/router'
 
-export const RLink = ({href, ...props}: LinkProps) => (
+export const RLink = React.forwardRef(({href, ...props}: LinkProps, ref) => (
   // @ts-expect-error there's something incompatible with the `color` prop, not sure if it's a real issue or just a problem with the typescript definitions
-  <RedwoodLink to={href} {...props} />
-)
+  <RedwoodLink to={href} {...props} ref={ref} />
+))
 
 export const InternalLink = (props: LinkProps) => (
   <ChakraLink as={RLink} {...props} />


### PR DESCRIPTION
This lets us use RLinks to create buttons that act as links to other pages within the Redwood app.