### PR TITLE
Treat a StarkNet 0 as a null for timestamps

### DIFF
--- a/redwood/api/jest.config.js
+++ b/redwood/api/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = require('@redwoodjs/testing/config/jest/api')
+const config = require('@redwoodjs/testing/config/jest/api')
+
+config.clearMocks = true
+
+module.exports = config

--- a/redwood/api/src/lib/serializers.test.ts
+++ b/redwood/api/src/lib/serializers.test.ts
@@ -1,4 +1,8 @@
-import {parseStarknetAddress, parseEthereumAddress} from './serializers'
+import {
+  parseStarknetAddress,
+  parseEthereumAddress,
+  parseTimestamp,
+} from './serializers'
 
 describe('parseStarknetAddress', () => {
   test('parses even-length addresses to a canonical form', () => {
@@ -41,5 +45,11 @@ describe('parseEthereumAddress', () => {
   test('parses a null address', () => {
     expect(parseEthereumAddress('0x0')).toEqual(null)
     // expect(parseEthereumAddress(null)).toEqual(null)
+  })
+})
+
+describe('parseTimestamp', () => {
+  test('parses uninitialized values', () => {
+    expect(parseTimestamp('0x0')).toEqual(null)
   })
 })

--- a/redwood/api/src/lib/serializers.ts
+++ b/redwood/api/src/lib/serializers.ts
@@ -5,11 +5,14 @@ import {getAddress} from 'ethers/lib/utils'
 
 type Felt = string
 
+export const isInitialized = (felt: Felt) => felt && felt !== '0x0'
+
 // Note: only safe for numbers that can be represented as a Javascript int
 export const parseNumber = (number: Felt) => parseInt(number, 16)
 
-export const parseBoolean = (boolean: Felt) => parseInt(boolean) === 1
-export const parseTimestamp = (timestamp: Felt) => new Date(parseInt(timestamp))
+export const parseBoolean = (boolean: Felt) => parseNumber(boolean) === 1
+export const parseTimestamp = (timestamp: Felt) =>
+  isInitialized(timestamp) ? new Date(parseNumber(timestamp)) : null
 
 export const bytesToFelt = (bytes: Uint8Array) => {
   assert(bytes.length <= 31, 'Error: cids on Cairo must be 31 bytes')
@@ -58,7 +61,3 @@ export const parseEthereumAddress = (address: Felt) => {
     return null
   }
 }
-
-export const numToHex = (num: number) => '0x' + num.toString(16)
-
-export const isInitialized = (felt: Felt) => felt && felt !== '0x0'

--- a/redwood/api/src/tasks/syncStarknetState.test.ts
+++ b/redwood/api/src/tasks/syncStarknetState.test.ts
@@ -67,4 +67,37 @@ describe('importProfile', () => {
       challengeTimestamp: '1970-01-02T10:17:36.789Z',
     })
   })
+
+  test("doesn't send notifications for unchallenged profiles", async () => {
+    mocked(exportProfileById).mockResolvedValueOnce({
+      profile: {
+        cid: '0x170121b909f5bf9672d64c328fb6196c0042b5bac45a7ce829b3a161a186c',
+        ethereum_address: '0x4956f0cd',
+        submitter_address: '0x165dabd',
+        submission_timestamp: '0x929',
+        is_notarized: '0x1',
+        last_recorded_status: '0x0',
+        challenge_timestamp: '0x0',
+        challenger_address:
+          '0x7283241e75fe4bfa64af202c1243b56e7ab30c7ea41a6e2c6000c5874670dc4',
+        challenge_evidence_cid:
+          '0x170121b6e2ca4f121dea9096755acf32b4caa2d955b1a025b5ff8a8f7fdb6',
+        owner_evidence_cid: '0x0',
+        adjudication_timestamp: '0x0',
+        adjudicator_evidence_cid: '0x0',
+        did_adjudicator_verify_profile: '0x0',
+        appeal_timestamp: '0x0',
+        super_adjudication_timestamp: '0x0',
+        did_super_adjudicator_verify_profile: '0x0',
+      },
+      num_profiles: '0xa',
+      is_verified: '0x1',
+      current_status: '0x0',
+      now: '0x75bcd15',
+    })
+
+    await importProfile(1)
+
+    expect(mocked(sendMessage).mock.calls.length).toBe(0)
+  })
 })

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -65,7 +65,7 @@ export const importProfile = async (profileId: number) => {
     ...(await readCids(cid)),
 
     ethereumAddress: parseEthereumAddress(profile.ethereum_address),
-    submissionTimestamp: parseTimestamp(profile.submission_timestamp),
+    submissionTimestamp: parseTimestamp(profile.submission_timestamp)!,
 
     notarized: parseBoolean(profile.is_notarized),
 


### PR DESCRIPTION
We should probably assume that a 0 in a timestamp felt means `null`, not January 1 1970.