### PR TITLE
Refactor AppLayout to extract navbar

### DIFF
--- a/redwood/web/src/Routes.tsx
+++ b/redwood/web/src/Routes.tsx
@@ -15,10 +15,10 @@ const Routes = () => {
           <Route path="/sign-up/connect" page={SignUpConnectWalletPage} name="signUpConnectWallet" />
           <Route path="/sign-up/allow-camera" page={SignUpAllowCameraPage} name="signUpAllowCamera" />
           <Route path="/sign-up/photo" page={SignUpPhotoPage} name="signUpPhoto" />
-          {/* @ts-expect-error bad RW types */}
+          {/* @ts-expect-error https://github.com/redwoodjs/redwood/pull/4219 */}
           <Route path="/sign-up/video" page={SignUpVideoPage} name="signUpVideo" />
           <Route path="/sign-up/email" page={SignUpEmailPage} name="signUpEmail" />
-          {/* @ts-expect-error bad RW types */}
+          {/* @ts-expect-error https://github.com/redwoodjs/redwood/pull/4219 */}
           <Route path="/sign-up/submit" page={SignUpSubmitPage} name="signUpSubmit" />
           <Route path="/sign-up/submitted" page={SignUpSubmittedPage} name="signUpSubmitted" />
         </Set>

--- a/redwood/web/src/Routes.tsx
+++ b/redwood/web/src/Routes.tsx
@@ -1,31 +1,36 @@
 import {Route, Router, Set} from '@redwoodjs/router'
 import AppLayout from './layouts/AppLayout/AppLayout'
+import NavLayout from './layouts/NavLayout/NavLayout'
 import ChallengeProfilePage from './pages/ChallengeProfilePage/ChallengeProfilePage'
 import SignUpLayout from 'src/pages/SignUp/SignUpLayout'
 
 const Routes = () => {
   return (
     <Router>
-      <Route path="/" page={SplashPage} name="splash" />
       <Set wrap={AppLayout}>
-        <Route path="/profiles" page={ProfilesPage} name="profiles" />
-        <Route path="/profiles/{id}" page={ProfilePage} name="profile" />
-        <Route path="/profiles/{id}/challenge" page={ChallengeProfilePage} name="challengeProfile" />
-
-        <Route path="/unsubmitted-profiles" page={UnsubmittedProfilesPage} name="unsubmittedProfiles" />
-        <Route path="/create-connection" page={CreateConnectionPage} name="createConnection" />
-        <Route path="/test-transaction" page={TestTransactionPage} name="testTransaction" />
-        <Route notfound page={NotFoundPage} />
+        <Route path="/" page={SplashPage} name="splash" />
         <Set wrap={SignUpLayout}>
           <Route path="/sign-up" page={SignUpIntroPage} name="signUpIntro" />
           <Route path="/sign-up/{purposeIdentifier}/{externalAddress}" page={SignUpIntroPage} name="signUpAndconnect" />
           <Route path="/sign-up/connect" page={SignUpConnectWalletPage} name="signUpConnectWallet" />
           <Route path="/sign-up/allow-camera" page={SignUpAllowCameraPage} name="signUpAllowCamera" />
           <Route path="/sign-up/photo" page={SignUpPhotoPage} name="signUpPhoto" />
+          {/* @ts-expect-error bad RW types */}
           <Route path="/sign-up/video" page={SignUpVideoPage} name="signUpVideo" />
           <Route path="/sign-up/email" page={SignUpEmailPage} name="signUpEmail" />
+          {/* @ts-expect-error bad RW types */}
           <Route path="/sign-up/submit" page={SignUpSubmitPage} name="signUpSubmit" />
           <Route path="/sign-up/submitted" page={SignUpSubmittedPage} name="signUpSubmitted" />
+        </Set>
+        <Set wrap={NavLayout}>
+          <Route path="/profiles" page={ProfilesPage} name="profiles" />
+          <Route path="/profiles/{id}" page={ProfilePage} name="profile" />
+          <Route path="/profiles/{id}/challenge" page={ChallengeProfilePage} name="challengeProfile" />
+
+          <Route path="/unsubmitted-profiles" page={UnsubmittedProfilesPage} name="unsubmittedProfiles" />
+          <Route path="/create-connection" page={CreateConnectionPage} name="createConnection" />
+          <Route path="/test-transaction" page={TestTransactionPage} name="testTransaction" />
+          <Route notfound page={NotFoundPage} />
         </Set>
       </Set>
     </Router>

--- a/redwood/web/src/components/requireEthAddress.tsx
+++ b/redwood/web/src/components/requireEthAddress.tsx
@@ -1,11 +1,12 @@
-import {Redirect, routes} from '@redwoodjs/router'
+import {routes} from '@redwoodjs/router'
 import {ReactElement, useContext} from 'react'
 import UserContext from 'src/layouts/UserContext'
+import {appNav} from 'src/lib/util'
 
 const requireEthAddress = (element: ReactElement) => {
   const RequireEthAddress: React.FC = (props) => {
     const {ethereumAddress} = useContext(UserContext)
-    if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+    if (!ethereumAddress) return appNav(routes.signUpIntro(), {replace: true})
     return React.cloneElement(element, {...props, ethereumAddress})
   }
 

--- a/redwood/web/src/config/theme.ts
+++ b/redwood/web/src/config/theme.ts
@@ -1,4 +1,5 @@
-import {extendTheme} from '@chakra-ui/react'
+import {extendTheme, theme as baseTheme} from '@chakra-ui/react'
+import {StyleFunctionProps} from '@chakra-ui/theme-tools'
 
 const theme = extendTheme({
   components: {
@@ -22,8 +23,27 @@ const theme = extendTheme({
         },
       },
       defaultProps: {
-        // you can name it whatever you want
         variant: 'primary',
+      },
+    },
+    Button: {
+      variants: {
+        'signup-primary': (props: StyleFunctionProps) => ({
+          alignSelf: 'center',
+          ...baseTheme.components.Button.variants.solid({
+            ...props,
+            colorScheme: 'purple',
+          }),
+          ...baseTheme.components.Button.sizes['lg'],
+        }),
+        'signup-secondary': (props: StyleFunctionProps) => ({
+          alignSelf: 'center',
+          ...baseTheme.components.Button.variants.link({
+            ...props,
+            colorScheme: 'purple',
+          }),
+          ...baseTheme.components.Button.sizes['lg'],
+        }),
       },
     },
   },

--- a/redwood/web/src/layouts/AppLayout/AppLayout.tsx
+++ b/redwood/web/src/layouts/AppLayout/AppLayout.tsx
@@ -1,26 +1,10 @@
-import {Flex, useToast} from '@chakra-ui/react'
-import {useLocation} from '@redwoodjs/router'
-import {useEffect} from 'react'
-import NavBar from './NavBar'
-
-// Don't run this code within AppLayout itself to avoid re-rendering the page
-// chrome every time we navigate to a new page.
-const LayoutEffects = () => {
-  const {pathname} = useLocation()
-  const toast = useToast()
-
-  // dismiss all active toasts
-  useEffect(toast.closeAll, [pathname])
-  return null
-}
+import {Flex} from '@chakra-ui/react'
+import {ToastManager} from './ToastManager'
 
 const AppLayout: React.FC = ({children}) => (
   <Flex flexDir="column" minH="100vh">
-    <NavBar />
-    <Flex flexDir="column" p={8} flex="1">
-      {children}
-    </Flex>
-    <LayoutEffects />
+    <ToastManager />
+    {children}
   </Flex>
 )
 

--- a/redwood/web/src/layouts/AppLayout/ToastManager.tsx
+++ b/redwood/web/src/layouts/AppLayout/ToastManager.tsx
@@ -1,0 +1,31 @@
+import {useToast, UseToastOptions} from '@chakra-ui/react'
+import {useLocation} from '@redwoodjs/router'
+import {useEffect} from 'react'
+
+const QUEUED_TOAST_KEY = 'ZORRO_QUEUED_TOAST'
+
+export const ToastManager = () => {
+  const {pathname} = useLocation()
+  const toast = useToast()
+
+  // dismiss all active toasts every time we change pages
+  useEffect(() => {
+    toast.closeAll()
+
+    const queuedToast = localStorage.getItem(QUEUED_TOAST_KEY)
+    localStorage.removeItem(QUEUED_TOAST_KEY)
+    if (queuedToast) {
+      try {
+        toast(JSON.parse(queuedToast))
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }, [pathname])
+  return null
+}
+
+// Queue a toast to show as soon as we navigate to the next page.
+export const queueToast = (options: UseToastOptions) => {
+  localStorage.setItem(QUEUED_TOAST_KEY, JSON.stringify(options))
+}

--- a/redwood/web/src/layouts/NavLayout/NavBar.tsx
+++ b/redwood/web/src/layouts/NavLayout/NavBar.tsx
@@ -16,7 +16,7 @@ import {BsGrid, BsPersonBadge, BsPersonPlus} from 'react-icons/bs'
 import ConnectButton from 'src/components/ConnectButton/ConnectButton'
 import {RLink} from 'src/components/links'
 import UserContext from '../UserContext'
-import Logo from './Logo'
+import Logo from '../AppLayout/Logo'
 
 type NavItem = {
   label: string

--- a/redwood/web/src/layouts/NavLayout/NavLayout.tsx
+++ b/redwood/web/src/layouts/NavLayout/NavLayout.tsx
@@ -1,0 +1,13 @@
+import {Flex} from '@chakra-ui/react'
+import NavBar from './NavBar'
+
+const NavLayout: React.FC = ({children}) => (
+  <Flex flexDir="column" minH="100vh">
+    <NavBar />
+    <Flex flexDir="column" p={8} flex="1">
+      {children}
+    </Flex>
+  </Flex>
+)
+
+export default NavLayout

--- a/redwood/web/src/lib/util.ts
+++ b/redwood/web/src/lib/util.ts
@@ -1,3 +1,9 @@
+import {NavigateOptions} from '@redwoodjs/router/dist/history'
+import {navigate} from '@redwoodjs/router'
+import {UseToastOptions} from '@chakra-ui/react'
+import {queueToast} from 'src/layouts/AppLayout/ToastManager'
+import {omit} from 'lodash'
+
 export const dataUrlToBlob = async (dataUrl: string) =>
   await (await fetch(dataUrl)).blob()
 
@@ -9,4 +15,13 @@ export type ArrayElement<ArrayType extends readonly unknown[]> =
 
 export const assert = (condition: boolean, message: string) => {
   if (!condition) throw new Error(message)
+}
+
+export const appNav = (
+  url: string,
+  options?: NavigateOptions & {toast?: UseToastOptions}
+) => {
+  if (options?.toast) queueToast(options.toast)
+  navigate(url, omit(options, 'toast'))
+  return null
 }

--- a/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
+++ b/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
@@ -20,13 +20,12 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import {Form, useForm} from '@redwoodjs/forms'
-import {Redirect, routes} from '@redwoodjs/router'
+import {routes} from '@redwoodjs/router'
 import {CellSuccessProps, createCell, MetaTags} from '@redwoodjs/web'
 import {ReactElement} from 'react'
 import ResizeTextarea from 'react-textarea-autosize'
 import {InternalLink, RLink} from 'src/components/links'
 import {cairoCompatibleAdd} from 'src/lib/ipfs'
-import {appNav} from 'src/lib/util'
 import NotFoundPage from 'src/pages/NotFoundPage'
 import {
   ChallengePageQuery,

--- a/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
+++ b/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
@@ -26,6 +26,7 @@ import {ReactElement} from 'react'
 import ResizeTextarea from 'react-textarea-autosize'
 import {InternalLink, RLink} from 'src/components/links'
 import {cairoCompatibleAdd} from 'src/lib/ipfs'
+import {appNav} from 'src/lib/util'
 import NotFoundPage from 'src/pages/NotFoundPage'
 import {
   ChallengePageQuery,
@@ -201,17 +202,19 @@ const Success = (props: CellSuccessProps<ChallengePageQuery>) => {
   const profile = props.cachedProfile
   if (!profile) return <NotFoundPage />
 
-  // TODO: use a flash message to explain why the challenge page isn't available in these states
-  const profileRedirect = <Redirect to={routes.profile({id: profile.id})} />
-
   const bodyContent: {[key in StatusEnum]: ReactElement | null} = {
     NOT_CHALLENGED: <NotChallenged query={props} />,
     CHALLENGED: <Text>profile challenged</Text>,
     ADJUDICATION_ROUND_COMPLETED: null,
-    APPEALED: profileRedirect,
-    APPEAL_OPPORTUNITY_EXPIRED: profileRedirect,
-    SUPER_ADJUDICATION_ROUND_COMPLETED: profileRedirect,
-    SETTLED: profileRedirect,
+    APPEALED: (
+      <Text>
+        You cannot challenge ths profile because the latest challenge has been
+        appealed.
+      </Text>
+    ),
+    APPEAL_OPPORTUNITY_EXPIRED: <NotChallenged query={props} />,
+    SUPER_ADJUDICATION_ROUND_COMPLETED: <NotChallenged query={props} />,
+    SETTLED: <NotChallenged query={props} />,
   }
 
   return (

--- a/redwood/web/src/pages/SignUp/AllowCameraPage/AllowCameraPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/AllowCameraPage/AllowCameraPage.stories.tsx
@@ -1,10 +1,13 @@
+import {StoryMocks} from 'src/lib/StoryMocks'
 import SignUpLayout from '../SignUpLayout'
 import AllowCameraPage from './AllowCameraPage'
 
 export const Page = () => (
-  <SignUpLayout>
-    <AllowCameraPage />
-  </SignUpLayout>
+  <StoryMocks>
+    <SignUpLayout>
+      <AllowCameraPage />
+    </SignUpLayout>
+  </StoryMocks>
 )
 
 export default {title: 'Pages/Sign Up/3. Allow Camera'}

--- a/redwood/web/src/pages/SignUp/AllowCameraPage/AllowCameraPage.tsx
+++ b/redwood/web/src/pages/SignUp/AllowCameraPage/AllowCameraPage.tsx
@@ -14,7 +14,7 @@ const AllowCameraPage: React.FC = () => {
 
   const requestPermissions = async () => {
     requestMediaPermissions()
-      .then(() => navigate(routes.signUpPhoto()))
+      .then(() => navigate(routes.signUpRecord()))
       .catch((err: MediaPermissionsError) => {
         if (err.type === MediaPermissionsErrorType.SystemPermissionDenied) {
           cameraError({
@@ -45,7 +45,7 @@ const AllowCameraPage: React.FC = () => {
     <VStack maxW="md" mx="auto" spacing="6" flex="1">
       <SignUpLogo />
       <MetaTags title="Allow Camera" />
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <Text>Everyone who registers records a short video</Text>
       <Text>
         These videos help ensure that each unique person only registers once.

--- a/redwood/web/src/pages/SignUp/ConnectWalletPage/ConnectWalletPage.tsx
+++ b/redwood/web/src/pages/SignUp/ConnectWalletPage/ConnectWalletPage.tsx
@@ -1,4 +1,4 @@
-import {Spacer, Text, VStack} from '@chakra-ui/layout'
+import {Spacer, Text, Stack} from '@chakra-ui/layout'
 import {routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
 import {useContext} from 'react'
@@ -16,7 +16,7 @@ const ConnectWalletPage: React.FC<{
     return appNav(routes.signUpAllowCamera(), {replace: true})
 
   return (
-    <VStack spacing="6" flex="1">
+    <Stack spacing="6" flex="1">
       <SignUpLogo />
       <MetaTags title="Sign Up" />
       <Spacer />
@@ -24,10 +24,10 @@ const ConnectWalletPage: React.FC<{
         To protect your privacy, connect an Ethereum wallet and{' '}
         <strong>create a new address</strong>.
       </Text>
-      <ConnectButton colorScheme="purple" my="8">
+      <ConnectButton variant="signup-primary" my="8">
         Connect wallet
       </ConnectButton>
-    </VStack>
+    </Stack>
   )
 }
 

--- a/redwood/web/src/pages/SignUp/ConnectWalletPage/ConnectWalletPage.tsx
+++ b/redwood/web/src/pages/SignUp/ConnectWalletPage/ConnectWalletPage.tsx
@@ -1,9 +1,10 @@
 import {Spacer, Text, VStack} from '@chakra-ui/layout'
-import {Redirect, routes} from '@redwoodjs/router'
+import {routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
 import {useContext} from 'react'
 import ConnectButton from 'src/components/ConnectButton/ConnectButton'
 import UserContext from 'src/layouts/UserContext'
+import {appNav} from 'src/lib/util'
 import SignUpLogo from '../SignUpLogo'
 
 const ConnectWalletPage: React.FC<{
@@ -12,13 +13,13 @@ const ConnectWalletPage: React.FC<{
 }> = () => {
   const {ethereumAddress} = useContext(UserContext)
   if (ethereumAddress != null)
-    return <Redirect to={routes.signUpAllowCamera()} />
+    return appNav(routes.signUpAllowCamera(), {replace: true})
 
   return (
     <VStack spacing="6" flex="1">
       <SignUpLogo />
       <MetaTags title="Sign Up" />
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <Text>
         To protect your privacy, connect an Ethereum wallet and{' '}
         <strong>create a new address</strong>.

--- a/redwood/web/src/pages/SignUp/EmailPage/EmailPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/EmailPage/EmailPage.stories.tsx
@@ -13,4 +13,4 @@ export const Page = () => (
   </StoryMocks>
 )
 
-export default {title: 'Pages/Sign Up/5. Email'}
+export default {title: 'Pages/Sign Up/6. Email'}

--- a/redwood/web/src/pages/SignUp/EmailPage/EmailPage.tsx
+++ b/redwood/web/src/pages/SignUp/EmailPage/EmailPage.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Heading,
   Input,
   ListItem,
   Spacer,
@@ -9,14 +8,15 @@ import {
   Text,
   UnorderedList,
 } from '@chakra-ui/react'
-import {Redirect, routes} from '@redwoodjs/router'
-import {MetaTags, useMutation} from '@redwoodjs/web'
+import {routes} from '@redwoodjs/router'
+import {useMutation} from '@redwoodjs/web'
 import {useContext, useEffect, useRef, useState} from 'react'
 import {RLink} from 'src/components/links'
 import UserContext from 'src/layouts/UserContext'
 import {appNav} from 'src/lib/util'
 import {CreateUserMutation, CreateUserMutationVariables} from 'types/graphql'
 import SignUpLogo from '../SignUpLogo'
+import Title from '../Title'
 
 const EmailPage = () => {
   const user = useContext(UserContext)
@@ -64,10 +64,7 @@ const EmailPage = () => {
     <form onSubmit={handleSubmit} style={{display: 'flex', flex: '1'}}>
       <Stack spacing="6" flex="1">
         <SignUpLogo />
-        <MetaTags title="Email Notifications" />
-        <Heading size="md" textAlign="center">
-          Enter email
-        </Heading>
+        <Title title="Enter email" />
         <Input
           type="email"
           name="email"
@@ -84,19 +81,13 @@ const EmailPage = () => {
           </UnorderedList>
         </Box>
         <Spacer />
-        <Button
-          colorScheme="purple"
-          alignSelf="center"
-          type="submit"
-          disabled={!emailValid}
-        >
+        <Button variant="signup-primary" type="submit" disabled={!emailValid}>
           Continue
         </Button>
         <Button
-          variant="link"
+          variant="signup-secondary"
           as={RLink}
           href={routes.signUpSubmit()}
-          colorScheme="purple"
         >
           Skip
         </Button>

--- a/redwood/web/src/pages/SignUp/EmailPage/EmailPage.tsx
+++ b/redwood/web/src/pages/SignUp/EmailPage/EmailPage.tsx
@@ -14,16 +14,18 @@ import {MetaTags, useMutation} from '@redwoodjs/web'
 import {useContext, useEffect, useRef, useState} from 'react'
 import {RLink} from 'src/components/links'
 import UserContext from 'src/layouts/UserContext'
+import {appNav} from 'src/lib/util'
 import {CreateUserMutation, CreateUserMutationVariables} from 'types/graphql'
 import SignUpLogo from '../SignUpLogo'
 
 const EmailPage = () => {
   const user = useContext(UserContext)
-  if (!user?.ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+  if (!user?.ethereumAddress)
+    return appNav(routes.signUpIntro(), {replace: true})
 
   if (user.user?.hasEmail) {
     // We don't support changing emails yet
-    return <Redirect to={routes.signUpSubmit()} />
+    return appNav(routes.signUpSubmit(), {replace: true})
   }
 
   const [email, setEmail] = useState<string>('')
@@ -81,7 +83,7 @@ const EmailPage = () => {
             <ListItem>Citizenship expiration</ListItem>
           </UnorderedList>
         </Box>
-        <Spacer display={['initial', 'none']} />
+        <Spacer />
         <Button
           colorScheme="purple"
           alignSelf="center"

--- a/redwood/web/src/pages/SignUp/IntroPage/IntroPage.tsx
+++ b/redwood/web/src/pages/SignUp/IntroPage/IntroPage.tsx
@@ -1,11 +1,12 @@
 import {Heading, Spacer, Text, VStack} from '@chakra-ui/layout'
 import {Button, useToast} from '@chakra-ui/react'
-import {Redirect, routes} from '@redwoodjs/router'
+import {routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
 import {useContext, useEffect} from 'react'
 import {RLink} from 'src/components/links'
 import UserContext from 'src/layouts/UserContext'
 import {save as saveIntendedConnection} from 'src/lib/intendedConnectionStorage'
+import {appNav} from 'src/lib/util'
 import SignUpLogo from '../SignUpLogo'
 
 const IntroPage: React.FC<{
@@ -15,7 +16,7 @@ const IntroPage: React.FC<{
   const {cachedProfile} = useContext(UserContext)
 
   if (cachedProfile != null)
-    return <Redirect to={routes.profile({id: cachedProfile.id})} />
+    return appNav(routes.profile({id: cachedProfile.id}))
 
   useEffect(() => {
     if (purposeIdentifier && externalAddress) {
@@ -37,7 +38,7 @@ const IntroPage: React.FC<{
   return (
     <VStack spacing="6" flex="1">
       <SignUpLogo />
-      <MetaTags title="Connect Wallet" />
+      <MetaTags title="Sign Up" />
       <Heading size="lg" pb="4" alignSelf="flex-start">
         Zorro: web3 citizenship
       </Heading>
@@ -48,7 +49,7 @@ const IntroPage: React.FC<{
       <Text>
         It takes about 8 minutes. The costs are covered by the Zorro community.
       </Text>
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <Button
         as={RLink}
         href={routes.signUpConnectWallet()}

--- a/redwood/web/src/pages/SignUp/IntroPage/IntroPage.tsx
+++ b/redwood/web/src/pages/SignUp/IntroPage/IntroPage.tsx
@@ -1,4 +1,4 @@
-import {Heading, Spacer, Text, VStack} from '@chakra-ui/layout'
+import {Heading, Spacer, Stack, Text} from '@chakra-ui/layout'
 import {Button, useToast} from '@chakra-ui/react'
 import {routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
@@ -36,7 +36,7 @@ const IntroPage: React.FC<{
   }
 
   return (
-    <VStack spacing="6" flex="1">
+    <Stack spacing="6" flex="1">
       <SignUpLogo />
       <MetaTags title="Sign Up" />
       <Heading size="lg" pb="4" alignSelf="flex-start">
@@ -51,16 +51,16 @@ const IntroPage: React.FC<{
       </Text>
       <Spacer />
       <Button
+        variant="signup-primary"
         as={RLink}
         href={routes.signUpConnectWallet()}
-        colorScheme="purple"
       >
         Let's go!
       </Button>
-      <Button variant="link" colorScheme="purple" onClick={alreadyRegistered}>
+      <Button variant="signup-secondary" onClick={alreadyRegistered}>
         I'm already registered
       </Button>
-    </VStack>
+    </Stack>
   )
 }
 

--- a/redwood/web/src/pages/SignUp/PhotoPage/PhotoPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/PhotoPage/PhotoPage.stories.tsx
@@ -1,0 +1,28 @@
+import {StoryMocks} from 'src/lib/StoryMocks'
+import SignUpLayout from '../SignUpLayout'
+import PhotoPage from './PhotoPage'
+
+export const Take_Photo = () => (
+  <StoryMocks user={{ethereumAddress: '0x456'}}>
+    <SignUpLayout>
+      <PhotoPage />
+    </SignUpLayout>
+  </StoryMocks>
+)
+
+export const Review = () => (
+  <StoryMocks
+    user={{ethereumAddress: '0x456'}}
+    state={{
+      signUp: {
+        photo: 'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+      },
+    }}
+  >
+    <SignUpLayout>
+      <PhotoPage />
+    </SignUpLayout>
+  </StoryMocks>
+)
+
+export default {title: 'Pages/Sign Up/4. Photo'}

--- a/redwood/web/src/pages/SignUp/PhotoPage/PhotoPage.tsx
+++ b/redwood/web/src/pages/SignUp/PhotoPage/PhotoPage.tsx
@@ -1,6 +1,6 @@
 import {Box, Spacer, Stack, Text} from '@chakra-ui/layout'
 import {Button, Image} from '@chakra-ui/react'
-import {navigate, Redirect, routes} from '@redwoodjs/router'
+import {navigate, routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
 import {requestMediaPermissions} from 'mic-check'
 import {useCallback, useContext, useEffect, useRef} from 'react'
@@ -8,12 +8,13 @@ import Webcam from 'react-webcam'
 import {RLink} from 'src/components/links'
 import {maybeCidToUrl} from 'src/components/SquareBox'
 import UserContext from 'src/layouts/UserContext'
+import {appNav} from 'src/lib/util'
 import {signUpSlice} from 'src/state/signUpSlice'
 import {useAppDispatch, useAppSelector} from 'src/state/store'
 
 const PhotoPage = () => {
   const {ethereumAddress} = useContext(UserContext)
-  if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+  if (!ethereumAddress) return appNav(routes.signUpIntro(), {replace: true})
 
   // Make sure we have camera permissions
   useEffect(() => {
@@ -46,7 +47,7 @@ const PhotoPage = () => {
           />
         )}
       </Box>
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <MetaTags title="Take photo" />
       {photo ? (
         <>

--- a/redwood/web/src/pages/SignUp/SignUpLayout.tsx
+++ b/redwood/web/src/pages/SignUp/SignUpLayout.tsx
@@ -1,19 +1,31 @@
-import {Flex} from '@chakra-ui/react'
+import {Flex, ScaleFade} from '@chakra-ui/react'
+import {useLocation} from '@redwoodjs/router'
 
-const SignUpLayout: React.FC = ({children}) => (
-  <Flex flexDir="column" minH="100vh" background="gray.200">
-    <Flex
-      flexDir="column"
-      maxW="md"
-      width="100%"
-      mx="auto"
-      flex="1"
-      background="white"
-      p="8"
-    >
-      {children}
+const SignUpLayout: React.FC = ({children}) => {
+  const {pathname} = useLocation()
+
+  return (
+    <Flex flexDir="column" minH="100vh" background="gray.200">
+      <ScaleFade
+        key={pathname}
+        initialScale={0.9}
+        in={true}
+        style={{flex: 1, display: 'flex'}}
+      >
+        <Flex
+          flexDir="column"
+          maxW="lg"
+          width="100%"
+          mx="auto"
+          flex="1"
+          background="white"
+          p="8"
+        >
+          {children}
+        </Flex>
+      </ScaleFade>
     </Flex>
-  </Flex>
-)
+  )
+}
 
 export default SignUpLayout

--- a/redwood/web/src/pages/SignUp/SignUpLayout.tsx
+++ b/redwood/web/src/pages/SignUp/SignUpLayout.tsx
@@ -1,8 +1,18 @@
 import {Flex} from '@chakra-ui/react'
 
 const SignUpLayout: React.FC = ({children}) => (
-  <Flex flexDir="column" maxW="md" width="100%" mx="auto" flex="1">
-    {children}
+  <Flex flexDir="column" minH="100vh" background="gray.200">
+    <Flex
+      flexDir="column"
+      maxW="md"
+      width="100%"
+      mx="auto"
+      flex="1"
+      background="white"
+      p="8"
+    >
+      {children}
+    </Flex>
   </Flex>
 )
 

--- a/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.stories.tsx
@@ -29,4 +29,4 @@ export const Submitting = () => (
   </StoryMocks>
 )
 
-export default {title: 'Pages/Sign Up/6. Submit'}
+export default {title: 'Pages/Sign Up/7. Submit'}

--- a/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.tsx
+++ b/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.tsx
@@ -1,9 +1,8 @@
-import {Button} from '@chakra-ui/button'
-import {Box, Spacer, Stack, Text} from '@chakra-ui/layout'
+import {Spacer, Text} from '@chakra-ui/layout'
 import {CircularProgress} from '@chakra-ui/progress'
-import {Heading, Image, VStack} from '@chakra-ui/react'
-import {navigate, Redirect, routes} from '@redwoodjs/router'
-import {MetaTags, useMutation} from '@redwoodjs/web'
+import {Image, Stack, Button} from '@chakra-ui/react'
+import {navigate, routes} from '@redwoodjs/router'
+import {useMutation} from '@redwoodjs/web'
 import React, {useContext} from 'react'
 import ReactPlayer from 'react-player'
 import {maybeCidToUrl} from 'src/components/SquareBox'
@@ -16,6 +15,8 @@ import {
   UpdateUnsubmittedProfileMutationVariables,
 } from 'types/graphql'
 import SignUpLogo from '../SignUpLogo'
+import Title from '../Title'
+import UserMediaBox from '../UserMediaBox'
 
 const SubmitPage = ({initialSubmitProgress = -1}) => {
   const {ethereumAddress} = useContext(UserContext)
@@ -95,11 +96,10 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
     navigate(routes.signUpSubmitted())
   }, [ethereumAddress, updateMutation])
 
-  const title = submitting ? 'Uploading video' : 'Ready to submit'
   return (
-    <VStack spacing="6" flex="1" width="100%">
+    <Stack spacing="6" flex="1" width="100%">
       <SignUpLogo />
-      <Heading size="md">{title}</Heading>
+      <Title title={submitting ? 'Uploading video' : 'Ready to submit'} />
       {submitting ? (
         <CircularProgress
           size="6rem"
@@ -109,17 +109,17 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
       ) : (
         <>
           <Stack direction="row">
-            <Box flex="1">
+            <UserMediaBox flex="1">
               <Image src={maybeCidToUrl(signUpState.photo)} />
-            </Box>
-            <Box flex="1">
+            </UserMediaBox>
+            <UserMediaBox flex="1">
               <ReactPlayer
                 url={maybeCidToUrl(signUpState.video)}
                 controls
                 width="100%"
                 height="100%"
               />
-            </Box>
+            </UserMediaBox>
           </Stack>
 
           <Text>
@@ -128,12 +128,11 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
           </Text>
         </>
       )}
-      <MetaTags title={title} />
       <Spacer />
-      <Button colorScheme="purple" onClick={submit} disabled={submitting}>
+      <Button variant="signup-primary" onClick={submit} disabled={submitting}>
         Submit application
       </Button>
-    </VStack>
+    </Stack>
   )
 }
 

--- a/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.tsx
+++ b/redwood/web/src/pages/SignUp/SubmitPage/SubmitPage.tsx
@@ -9,7 +9,7 @@ import ReactPlayer from 'react-player'
 import {maybeCidToUrl} from 'src/components/SquareBox'
 import UserContext from 'src/layouts/UserContext'
 import ipfsClient from 'src/lib/ipfs'
-import {dataUrlToBlob, isLocalUrl} from 'src/lib/util'
+import {appNav, dataUrlToBlob, isLocalUrl} from 'src/lib/util'
 import {useAppSelector} from 'src/state/store'
 import {
   UpdateUnsubmittedProfileMutation,
@@ -19,7 +19,7 @@ import SignUpLogo from '../SignUpLogo'
 
 const SubmitPage = ({initialSubmitProgress = -1}) => {
   const {ethereumAddress} = useContext(UserContext)
-  if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+  if (!ethereumAddress) return appNav(routes.signUpIntro(), {replace: true})
 
   const [submitProgress, setSubmitProgress] = React.useState(
     initialSubmitProgress
@@ -28,7 +28,7 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
   const signUpState = useAppSelector((state) => state.signUp)
 
   if (signUpState.photo == null || signUpState.video == null)
-    return <Redirect to={routes.signUpVideo()} />
+    return appNav(routes.signUpPhoto(), {replace: true})
 
   const [updateMutation] = useMutation<
     UpdateUnsubmittedProfileMutation,
@@ -129,7 +129,7 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
         </>
       )}
       <MetaTags title={title} />
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <Button colorScheme="purple" onClick={submit} disabled={submitting}>
         Submit application
       </Button>

--- a/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.stories.tsx
@@ -32,4 +32,4 @@ export const Unviewed = () => {
   )
 }
 
-export default {title: 'Pages/Sign Up/7. Submitted'}
+export default {title: 'Pages/Sign Up/8. Submitted'}

--- a/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
+++ b/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
@@ -3,13 +3,14 @@ import {FormControl, FormHelperText, FormLabel} from '@chakra-ui/form-control'
 import {Heading, Stack} from '@chakra-ui/layout'
 import {Input} from '@chakra-ui/react'
 import {useForm} from '@redwoodjs/forms'
-import {navigate, Redirect, routes} from '@redwoodjs/router'
+import {navigate, routes} from '@redwoodjs/router'
 import {CellSuccessProps, createCell, MetaTags} from '@redwoodjs/web'
 import React, {useCallback, useContext} from 'react'
 import {Card} from 'src/components/Card'
 import requireEthAddress from 'src/components/requireEthAddress'
 import UserContext from 'src/layouts/UserContext'
 import {usePusher} from 'src/lib/pusher'
+import {appNav} from 'src/lib/util'
 import ProfileStatus from 'src/pages/SignUp/ProfileStatus'
 import {SignUpSubmittedPageQuery} from 'types/graphql'
 import {useInterval} from 'usehooks-ts'
@@ -17,10 +18,23 @@ import {useInterval} from 'usehooks-ts'
 type FormFields = {email: string}
 
 const Success = (props: CellSuccessProps<SignUpSubmittedPageQuery>) => {
-  if (!props.unsubmittedProfile) return <Redirect to={routes.signUpIntro()} />
-
   const {ethereumAddress} = useContext(UserContext)
-  if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+  if (!ethereumAddress)
+    return appNav(routes.signUpIntro(), {
+      toast: {
+        title: 'Please connect a wallet',
+        status: 'warning',
+      },
+    })
+
+  if (!props.unsubmittedProfile)
+    return appNav(routes.signUpIntro(), {
+      toast: {
+        title:
+          "Couldn't find your submitted profile. Are you connected to the correct wallet?",
+        status: 'warning',
+      },
+    })
 
   const methods = useForm<FormFields>({
     defaultValues: {

--- a/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
+++ b/redwood/web/src/pages/SignUp/SubmittedPage/SubmittedPage.tsx
@@ -1,10 +1,10 @@
 import {Button, ButtonGroup} from '@chakra-ui/button'
 import {FormControl, FormHelperText, FormLabel} from '@chakra-ui/form-control'
-import {Heading, Stack} from '@chakra-ui/layout'
+import {Stack} from '@chakra-ui/layout'
 import {Input} from '@chakra-ui/react'
 import {useForm} from '@redwoodjs/forms'
 import {navigate, routes} from '@redwoodjs/router'
-import {CellSuccessProps, createCell, MetaTags} from '@redwoodjs/web'
+import {CellSuccessProps, createCell} from '@redwoodjs/web'
 import React, {useCallback, useContext} from 'react'
 import {Card} from 'src/components/Card'
 import requireEthAddress from 'src/components/requireEthAddress'
@@ -14,6 +14,7 @@ import {appNav} from 'src/lib/util'
 import ProfileStatus from 'src/pages/SignUp/ProfileStatus'
 import {SignUpSubmittedPageQuery} from 'types/graphql'
 import {useInterval} from 'usehooks-ts'
+import Title from '../Title'
 
 type FormFields = {email: string}
 
@@ -55,8 +56,7 @@ const Success = (props: CellSuccessProps<SignUpSubmittedPageQuery>) => {
 
   return (
     <Stack spacing="6" flex="1">
-      <MetaTags title="Profile Pending Approval" />
-      <Heading size="lg">Profile Pending Approval</Heading>
+      <Title title="Profile pending approval" />
       <ProfileStatus profile={props.unsubmittedProfile} />
       <ButtonGroup alignSelf="flex-end">
         <Button onClick={() => navigate(routes.signUpVideo())}>
@@ -74,6 +74,7 @@ const Success = (props: CellSuccessProps<SignUpSubmittedPageQuery>) => {
           </FormHelperText>
         </FormControl>
         <Button
+          variant="signup-primary"
           type="submit"
           colorScheme="blue"
           mt="6"

--- a/redwood/web/src/pages/SignUp/Title.tsx
+++ b/redwood/web/src/pages/SignUp/Title.tsx
@@ -1,0 +1,13 @@
+import {Heading} from '@chakra-ui/react'
+import {MetaTags} from '@redwoodjs/web'
+
+export default function Title({title}: {title: string}) {
+  return (
+    <>
+      <Heading size="md" textAlign="center">
+        {title}
+      </Heading>
+      <MetaTags title={title} />
+    </>
+  )
+}

--- a/redwood/web/src/pages/SignUp/UserMediaBox.tsx
+++ b/redwood/web/src/pages/SignUp/UserMediaBox.tsx
@@ -1,0 +1,21 @@
+import {AspectRatio, AspectRatioProps, Box} from '@chakra-ui/react'
+import {useAppSelector} from 'src/state/store'
+
+const UserMediaBox: React.FC<AspectRatioProps> = (props) => {
+  const {aspectRatio} = useAppSelector((state) => state.signUp)
+
+  if (!aspectRatio) {
+    return <Box {...props} />
+  }
+
+  return (
+    <AspectRatio
+      {...props}
+      ratio={aspectRatio}
+      background="black"
+      width="100%"
+    />
+  )
+}
+
+export default UserMediaBox

--- a/redwood/web/src/pages/SignUp/VideoPage/VideoPage.stories.tsx
+++ b/redwood/web/src/pages/SignUp/VideoPage/VideoPage.stories.tsx
@@ -41,4 +41,4 @@ export const Review = () => (
   </StoryMocks>
 )
 
-export default {title: 'Pages/Sign Up/4. Video'}
+export default {title: 'Pages/Sign Up/5. Video'}

--- a/redwood/web/src/pages/SignUp/VideoPage/VideoPage.tsx
+++ b/redwood/web/src/pages/SignUp/VideoPage/VideoPage.tsx
@@ -1,6 +1,6 @@
-import {Box, Spacer, Stack, Text} from '@chakra-ui/layout'
-import {Button} from '@chakra-ui/react'
-import {navigate, Redirect, routes} from '@redwoodjs/router'
+import {Spacer, Stack, Text} from '@chakra-ui/layout'
+import {Fade, Button} from '@chakra-ui/react'
+import {navigate, routes} from '@redwoodjs/router'
 import {MetaTags} from '@redwoodjs/web'
 import {requestMediaPermissions} from 'mic-check'
 import {useCallback, useContext, useEffect, useRef, useState} from 'react'
@@ -12,6 +12,13 @@ import UserContext from 'src/layouts/UserContext'
 import {appNav} from 'src/lib/util'
 import {signUpSlice} from 'src/state/signUpSlice'
 import {useAppDispatch, useAppSelector} from 'src/state/store'
+import UserMediaBox from '../UserMediaBox'
+
+export const videoConstraints: MediaTrackConstraints = {
+  facingMode: 'user',
+  width: 1280,
+  height: 720,
+}
 
 const VideoPage = ({mockRecording = false}) => {
   const {ethereumAddress} = useContext(UserContext)
@@ -24,7 +31,7 @@ const VideoPage = ({mockRecording = false}) => {
     })
 
   const {photo, video} = useAppSelector((state) => state.signUp)
-  if (!photo) return appNav(routes.signUpPhoto({replace: true}))
+  if (!photo) return appNav(routes.signUpPhoto(), {replace: true})
 
   // Make sure we have camera permissions
   useEffect(() => {
@@ -42,7 +49,7 @@ const VideoPage = ({mockRecording = false}) => {
     // @ts-expect-error TODO: why are we assigning to a supposedly readonly ref
     // here? Just copied the example from
     // https://codepen.io/mozmorris/pen/yLYKzyp?editors=0010
-    mediaRecorderRef.current = new MediaRecorder(webcam.current.stream, {
+    mediaRecorderRef.current = new MediaRecorder(webcamRef.current.stream, {
       mimeType: 'video/webm',
     })
     mediaRecorderRef.current.addEventListener('dataavailable', ({data}) => {
@@ -51,6 +58,7 @@ const VideoPage = ({mockRecording = false}) => {
       // video/x-matroska;codecs=avc1,opus, which Infura refuses to accept
       // as a valid mime-type when uploading the video.
       const video = data.slice(0, data.size, 'video/webm')
+      console.log('video')
       dispatch(signUpSlice.actions.setVideo(URL.createObjectURL(video)))
     })
     mediaRecorderRef.current.start()
@@ -62,80 +70,77 @@ const VideoPage = ({mockRecording = false}) => {
   }, [mediaRecorderRef, setRecording])
 
   return (
-    <Stack spacing="6" flex="1">
-      <Box background="black" width="100%">
-        {video ? (
-          <ReactPlayer
-            url={maybeCidToUrl(video)}
-            controls
-            width="100%"
-            height="100%"
-          />
-        ) : (
-          <Webcam
-            videoConstraints={{facingMode: 'user', width: 1280, height: 720}}
-            audio
-            muted
-            mirrored
-            ref={webcamRef}
-          />
+    <Fade
+      in={true}
+      key={video}
+      transition={{enter: {duration: 0.5}}}
+      style={{flex: 1, display: 'flex'}}
+    >
+      <Stack spacing="6" flex="1">
+        <UserMediaBox>
+          {video ? (
+            <ReactPlayer
+              url={maybeCidToUrl(video)}
+              controls
+              width="100%"
+              height="100%"
+            />
+          ) : (
+            <Webcam
+              videoConstraints={videoConstraints}
+              audio
+              muted
+              mirrored
+              ref={webcamRef}
+            />
+          )}
+        </UserMediaBox>
+        <Spacer />
+        <MetaTags title="Record Video" />
+        {!recording && !video && (
+          <>
+            <Text>
+              Ready to be sworn in? Just read the words on the next screen.
+            </Text>
+            <Button variant="signup-primary" onClick={startRecording}>
+              I'm ready, start recording
+            </Button>
+          </>
         )}
-      </Box>
-      <Spacer />
-      <MetaTags title="Record Video" />
-      {!recording && !video && (
-        <>
-          <Text>
-            Ready to be sworn in? Just read the words on the next screen.
-          </Text>
-          <Button
-            onClick={startRecording}
-            colorScheme="purple"
-            alignSelf="center"
-          >
-            I'm ready, start recording
-          </Button>
-        </>
-      )}
-      {recording && (
-        <>
-          <Text>
-            Say this:
-            <br />
-            <strong>
-              "I swear that this is my first time registering on Zorro"
-            </strong>
-          </Text>
-          <Button
-            onClick={stopRecording}
-            colorScheme="purple"
-            alignSelf="center"
-          >
-            Stop recording
-          </Button>
-        </>
-      )}
-      {video && !recording && (
-        <>
-          <Button
-            colorScheme="purple"
-            onClick={() => dispatch(signUpSlice.actions.setVideo(undefined))}
-            alignSelf="center"
-          >
-            Redo video
-          </Button>
-          <Button
-            as={RLink}
-            href={routes.signUpEmail()}
-            colorScheme="purple"
-            alignSelf="center"
-            px="12"
-          >
-            Continue
-          </Button>
-        </>
-      )}
-    </Stack>
+        {recording && (
+          <>
+            <Text>
+              Say this:
+              <br />
+              <strong>
+                "I swear that this is my first time registering on Zorro"
+              </strong>
+            </Text>
+            <Button variant="signup-primary" onClick={stopRecording}>
+              Stop recording
+            </Button>
+          </>
+        )}
+        {video && !recording && (
+          <>
+            <Button
+              variant="signup-primary"
+              onClick={() => dispatch(signUpSlice.actions.setVideo(undefined))}
+            >
+              Redo video
+            </Button>
+            <Button
+              variant="signup-primary"
+              as={RLink}
+              href={routes.signUpEmail()}
+              px="12"
+            >
+              Continue
+            </Button>
+          </>
+        )}
+      </Stack>
+    </Fade>
   )
 }
 

--- a/redwood/web/src/pages/SignUp/VideoPage/VideoPage.tsx
+++ b/redwood/web/src/pages/SignUp/VideoPage/VideoPage.tsx
@@ -9,15 +9,22 @@ import Webcam from 'react-webcam'
 import {RLink} from 'src/components/links'
 import {maybeCidToUrl} from 'src/components/SquareBox'
 import UserContext from 'src/layouts/UserContext'
+import {appNav} from 'src/lib/util'
 import {signUpSlice} from 'src/state/signUpSlice'
 import {useAppDispatch, useAppSelector} from 'src/state/store'
 
 const VideoPage = ({mockRecording = false}) => {
   const {ethereumAddress} = useContext(UserContext)
-  if (!ethereumAddress) return <Redirect to={routes.signUpIntro()} />
+  if (!ethereumAddress)
+    return appNav(routes.signUpIntro(), {
+      toast: {
+        title: 'Please connect a wallet',
+        status: 'warning',
+      },
+    })
 
   const {photo, video} = useAppSelector((state) => state.signUp)
-  if (!photo) return <Redirect to={routes.signUpPhoto()} />
+  if (!photo) return appNav(routes.signUpPhoto({replace: true}))
 
   // Make sure we have camera permissions
   useEffect(() => {
@@ -74,7 +81,7 @@ const VideoPage = ({mockRecording = false}) => {
           />
         )}
       </Box>
-      <Spacer display={['initial', 'none']} />
+      <Spacer />
       <MetaTags title="Record Video" />
       {!recording && !video && (
         <>

--- a/redwood/web/src/state/signUpSlice.ts
+++ b/redwood/web/src/state/signUpSlice.ts
@@ -6,6 +6,9 @@ type SignUpState = {
 
   // CID or local URL of the profile's avatar video
   video?: string
+
+  // Best guess at the webcam's aspect ratio
+  aspectRatio?: number
 }
 
 const initialState: SignUpState = {}
@@ -19,6 +22,9 @@ export const signUpSlice = createSlice({
     },
     setVideo: (state, action: PayloadAction<SignUpState['video']>) => {
       state.video = action.payload
+    },
+    setAspectRatio: (state, action: PayloadAction<number>) => {
+      state.aspectRatio = action.payload
     },
     reset: () => initialState,
   },


### PR DESCRIPTION
This lets us remove the navbar from the sign up layout without losing the toast functionality.

EDIT: also makes many tweaks to the sign-in flow as tracked at https://www.notion.so/28e2b02ecf064dfe9162db3360ec6643?v=daacc4a6fb8e4ae2bd532ff4a16dcce4&p=6565e3e29f2e425d9117b71a186b9834