### PR TITLE
Fix circular dependency on `syncStarknetState <-> unsubmittedProfiles`.

### DIFF
--- a/redwood/.env.defaults
+++ b/redwood/.env.defaults
@@ -32,3 +32,6 @@ INFURA_IPFS_SECRET=7089dd9b3331c0ec6d824a1f589e2fe9
 SMTP_HOST=smtp.ethereal.email
 SMTP_USER=irving.rau62@ethereal.email
 SMTP_PASSWORD=m7ADZ6TuH1mbbVvV4r
+
+# Coma-separated list of numbers to text when a profile comes in
+NOTARY_PHONE_NUMBERS='+15555555555,+14444444444'

--- a/redwood/api/src/lib/protocolNotifications.ts
+++ b/redwood/api/src/lib/protocolNotifications.ts
@@ -1,0 +1,3 @@
+// Just a placeholder really until we can build a more sophisticated system.
+export const NOTARY_PHONE_NUMBERS =
+  process.env.NOTARY_PHONE_NUMBERS?.split(',') || []

--- a/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
+++ b/redwood/api/src/services/cachedProfiles/cachedProfiles.ts
@@ -8,8 +8,6 @@ import {
 } from 'types/graphql'
 import {ContractCache} from '../contractCache/contractCache'
 
-import * as testing from 'src/tasks/syncStarknetState'
-console.log('more testing', {testing})
 export const cachedProfiles = async ({
   first,
   cursor,

--- a/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
+++ b/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
@@ -3,6 +3,7 @@ import type {
   UnsubmittedProfile as PrismaUnsubmittedProfile,
 } from '@prisma/client'
 import {db} from 'src/lib/db'
+import {NOTARY_PHONE_NUMBERS} from 'src/lib/protocolNotifications'
 import {pusher} from 'src/lib/pusher'
 import {sendMessage} from 'src/lib/twilio'
 import sendNotaryApproved from 'src/mailers/sendNotaryApproved'
@@ -27,12 +28,6 @@ const alertProfileUpdated = (
     'updated',
     {}
   )
-
-// Just hard-code these for now. Will get fancier later.
-export const NOTARIES = [
-  '+18016131318', // Kyle
-  '+16175958777', // Ted
-]
 
 export const unsubmittedProfiles = async ({
   pendingReview,
@@ -67,7 +62,7 @@ export const updateUnsubmittedProfile = async ({
 
   if (pendingCount > 0) {
     await sendMessage(
-      NOTARIES,
+      NOTARY_PHONE_NUMBERS,
       `${pendingCount} Zorro profiles awaiting review. http://localhost:8910/unsubmitted-profiles`
     )
   }

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -1,15 +1,16 @@
 import {CachedProfile} from '@prisma/client'
 import {CID} from 'ipfs-http-client'
 import {db} from 'src/lib/db'
+import {NOTARY_PHONE_NUMBERS} from 'src/lib/protocolNotifications'
 import {
+  parseBigNumber,
+  parseBigNumberAsDecimalString,
   parseBoolean,
   parseCid,
   parseEthereumAddress,
   parseNumber,
   parseStarknetAddress,
   parseTimestamp,
-  parseBigNumber,
-  parseBigNumberAsDecimalString,
 } from 'src/lib/serializers'
 import {exportProfileById, getNumProfiles} from 'src/lib/starknet'
 import {sendMessage} from 'src/lib/twilio'
@@ -19,7 +20,6 @@ import {
   parseChallengeStatus,
 } from 'src/services/cachedProfiles/cachedProfiles'
 import {maybeNotify} from 'src/services/notifications/notifications'
-import {NOTARIES} from 'src/services/unsubmittedProfiles/unsubmittedProfiles'
 
 const syncStarknetState = async (onlyNewProfiles = false) => {
   console.log('Starting StarkNet sync')
@@ -176,7 +176,10 @@ export const sendNotifications = async (profile: CachedProfile) => {
       async () => {
         // Just send a message to the notaries for now. Later we'll probably
         // want to post this to a Discord channel.
-        await sendMessage(NOTARIES, `New challenge to profile ${profile.id}`)
+        await sendMessage(
+          NOTARY_PHONE_NUMBERS,
+          `New challenge to profile ${profile.id}`
+        )
       }
     )
   }


### PR DESCRIPTION
This circular dependency was causing `syncStarknetState` to be undefined within `unsubmittedProfiles`, causing an error when a profile was submitted.