### PR TITLE
Add graphile-worker for lightweight background jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+dist/
+.redwood/

--- a/redwood/api/package.json
+++ b/redwood/api/package.json
@@ -8,6 +8,7 @@
     "@redwoodjs/graphql-server": "^0.42.0",
     "dayjs": "^1.10.7",
     "ethers": "^5.5.2",
+    "graphile-worker": "^0.12.2",
     "hex-to-array-buffer": "^2.0.0",
     "html-template-tag": "^4.0.0",
     "lodash": "^4.17.21",

--- a/redwood/api/src/functions/getVerifiedExternalAddresses/getVerifiedExternalAddresses.ts
+++ b/redwood/api/src/functions/getVerifiedExternalAddresses/getVerifiedExternalAddresses.ts
@@ -1,5 +1,5 @@
 import {db} from 'src/lib/db'
-import {isVerified} from 'src/services/cachedProfiles/cachedProfiles'
+import {isVerified} from 'src/services/cachedProfiles/helpers'
 import {Handler} from 'aws-lambda'
 
 type Params = {

--- a/redwood/api/src/functions/graphql.ts
+++ b/redwood/api/src/functions/graphql.ts
@@ -10,6 +10,9 @@ import {logger} from 'src/lib/logger'
 // Just make need to make sure this file gets loaded somewhere
 import type {} from 'types/environment'
 
+// Just need to make sure this file is imported at least once to start the background worker
+import 'src/lib/backgroundJobs'
+
 export const handler = createGraphQLHandler({
   loggerConfig: {logger, options: {operationName: true}},
   directives,

--- a/redwood/api/src/lib/backgroundJobs.ts
+++ b/redwood/api/src/lib/backgroundJobs.ts
@@ -1,0 +1,29 @@
+import {makeWorkerUtils, parseCronItems, run} from 'graphile-worker'
+
+const initialize = async () => {
+  await run({
+    concurrency: 5,
+    noHandleSignals: false,
+    taskDirectory: `${__dirname}/../tasks`,
+    parsedCronItems: parseCronItems([
+      // Sync Starknet state every hour at 35 minutes past the hour (arbitrary offset)
+      {
+        task: 'syncStarknetState',
+        pattern: '35 * * * *',
+        options: {
+          backfillPeriod: 0,
+          maxAttempts: 1,
+          queueName: 'scheduled_syncStarknetState',
+          priority: 10,
+        },
+      },
+    ]),
+  })
+
+  const workerUtils = await makeWorkerUtils({})
+  await workerUtils.migrate()
+}
+
+// We don't have any CPU or memory intensive tasks, so we can just run our
+// workers in the web process for now for simplicity.
+initialize()

--- a/redwood/api/src/services/cachedProfiles/helpers.ts
+++ b/redwood/api/src/services/cachedProfiles/helpers.ts
@@ -1,0 +1,122 @@
+import {CachedProfile as PrismaCachedProfile, StatusEnum} from '@prisma/client'
+import {ContractCache} from '../contractCache/contractCache'
+
+// Keep in sync with `StatusEnum` in `starknet/contracts/profile.cairo`
+const STATUS_ENUMS: {[enumVal: number]: StatusEnum} = {
+  0: StatusEnum.NOT_CHALLENGED,
+  1: StatusEnum.CHALLENGED,
+  2: StatusEnum.ADJUDICATION_ROUND_COMPLETED,
+  3: StatusEnum.APPEALED,
+  4: StatusEnum.APPEAL_OPPORTUNITY_EXPIRED,
+  5: StatusEnum.SUPER_ADJUDICATION_ROUND_COMPLETED,
+  6: StatusEnum.SETTLED,
+}
+
+export const parseChallengeStatus = (status: number): StatusEnum =>
+  STATUS_ENUMS[status]
+
+// Keep in sync with profile.cairo#_get_current_status
+
+export const currentStatus = (
+  profile: Pick<
+    PrismaCachedProfile,
+    | 'lastRecordedStatus'
+    | 'challengeTimestamp'
+    | 'adjudicationTimestamp'
+    | 'appealTimestamp'
+  >,
+  now = new Date()
+): StatusEnum => {
+  if (profile.lastRecordedStatus === StatusEnum.NOT_CHALLENGED) {
+    return StatusEnum.NOT_CHALLENGED
+  } else if (profile.lastRecordedStatus === StatusEnum.CHALLENGED) {
+    const timePassed =
+      now.getTime() - (profile.challengeTimestamp?.getTime() ?? 0)
+    const hasAppealOpportunityExpired =
+      ContractCache.adjudicationTimeWindow + ContractCache.appealTimeWindow <
+      timePassed
+    if (hasAppealOpportunityExpired)
+      return StatusEnum.APPEAL_OPPORTUNITY_EXPIRED
+
+    const hasAdjudicationOpportunityExpired =
+      ContractCache.adjudicationTimeWindow < timePassed
+    if (hasAdjudicationOpportunityExpired)
+      return StatusEnum.ADJUDICATION_ROUND_COMPLETED
+
+    return StatusEnum.CHALLENGED
+  } else if (
+    profile.lastRecordedStatus === StatusEnum.ADJUDICATION_ROUND_COMPLETED
+  ) {
+    const timePassed =
+      now.getTime() - (profile.adjudicationTimestamp?.getTime() ?? 0)
+
+    const hasAppealOpportunityExpired =
+      ContractCache.appealTimeWindow < timePassed
+    if (hasAppealOpportunityExpired)
+      return StatusEnum.APPEAL_OPPORTUNITY_EXPIRED
+
+    return StatusEnum.ADJUDICATION_ROUND_COMPLETED
+  } else if (profile.lastRecordedStatus === StatusEnum.APPEALED) {
+    const timePassed = now.getTime() - (profile.appealTimestamp?.getTime() ?? 0)
+
+    const hasSuperAdjudicationOpportunityExpired =
+      ContractCache.superAdjudicationTimeWindow < timePassed
+    if (hasSuperAdjudicationOpportunityExpired)
+      return StatusEnum.SUPER_ADJUDICATION_ROUND_COMPLETED
+
+    return StatusEnum.APPEALED
+  } else if (
+    profile.lastRecordedStatus === StatusEnum.SUPER_ADJUDICATION_ROUND_COMPLETED
+  ) {
+    return StatusEnum.SUPER_ADJUDICATION_ROUND_COMPLETED
+  } else if (profile.lastRecordedStatus === StatusEnum.SETTLED) {
+    return StatusEnum.SETTLED
+  } else {
+    throw new Error(`Unknown profile status: ${profile.lastRecordedStatus}`)
+  }
+}
+
+// Keep in sync with profile.cairo#get_is_in_provisional_time_window
+const isInProvisionalTimeWindow = (
+  profile: Pick<PrismaCachedProfile, 'submissionTimestamp'>,
+  now = new Date()
+): boolean => {
+  const timePassed = now.getTime() - profile.submissionTimestamp.getTime()
+  return timePassed < ContractCache.provisionalTimeWindow
+}
+
+// Keep in sync with profile.cairo#_get_is_verified
+export const isVerified = (
+  profile: Pick<
+    PrismaCachedProfile,
+    | 'lastRecordedStatus'
+    | 'notarized'
+    | 'challengeTimestamp'
+    | 'superAdjudicationTimestamp'
+    | 'didAdjudicatorVerifyProfile'
+    | 'didSuperAdjudicatorOverturnAdjudicator'
+    | 'adjudicationTimestamp'
+    | 'appealTimestamp'
+    | 'submissionTimestamp'
+  >,
+  now = new Date()
+): boolean => {
+  const status = currentStatus(profile, now)
+  if (status == StatusEnum.NOT_CHALLENGED) {
+    const isProvisional = isInProvisionalTimeWindow(profile, now)
+    return profile.notarized || !isProvisional
+  } else if (status == StatusEnum.CHALLENGED) {
+    const isPresumedInnocent =
+      ContractCache.provisionalTimeWindow <
+      (profile.challengeTimestamp?.getTime() ?? 0) -
+        profile.submissionTimestamp.getTime()
+
+    return isPresumedInnocent
+  } else if (profile.superAdjudicationTimestamp != null) {
+    return profile.didSuperAdjudicatorOverturnAdjudicator
+      ? !profile.didAdjudicatorVerifyProfile
+      : profile.didAdjudicatorVerifyProfile
+  } else if (profile.adjudicationTimestamp != null) {
+    return profile.didAdjudicatorVerifyProfile
+  } else return false
+}

--- a/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
+++ b/redwood/api/src/services/unsubmittedProfiles/unsubmittedProfiles.ts
@@ -138,7 +138,7 @@ export const approveProfile = async ({id}: MutationapproveProfileArgs) => {
 
   if (!profile) return false
 
-  await syncStarknetState(true)
+  await syncStarknetState({onlyNewProfiles: true})
   await db.unsubmittedProfile.delete({where: {id: parseInt(id)}})
   alertProfileUpdated(profile)
 

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -18,10 +18,10 @@ import {
   currentStatus,
   isVerified,
   parseChallengeStatus,
-} from 'src/services/cachedProfiles/cachedProfiles'
+} from 'src/services/cachedProfiles/helpers'
 import {maybeNotify} from 'src/services/notifications/notifications'
 
-const syncStarknetState = async (onlyNewProfiles = false) => {
+const syncStarknetState = async ({onlyNewProfiles = false} = {}) => {
   console.log('Starting StarkNet sync')
   let currentId = 0
   let maxId = await getNumProfiles()

--- a/redwood/package.json
+++ b/redwood/package.json
@@ -13,7 +13,8 @@
     "applyDevMigrations": "yarn redwood prisma migrate dev",
     "syncStarknetState": "yarn redwood exec syncStarknetState",
     "runChecks": "./run_checks.sh",
-    "storybook": "yarn rw storybook"
+    "storybook": "yarn rw storybook",
+    "clearSpuriousCache": "rm -rf api/node_modules/.prisma web/node_modules/.prisma"
   },
   "devDependencies": {
     "@redwoodjs/core": "^0.42.0"

--- a/redwood/scripts/syncStarknetState.ts
+++ b/redwood/scripts/syncStarknetState.ts
@@ -2,5 +2,5 @@ import syncStarknetState from '$api/src/tasks/syncStarknetState'
 
 export default async ({args}) => {
   console.log('Syncing StarkNet state...')
-  await syncStarknetState(!!args.onlyNew)
+  await syncStarknetState({onlyNewProfiles: !!args.onlyNew})
 }

--- a/redwood/yarn.lock
+++ b/redwood/yarn.lock
@@ -2563,6 +2563,11 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@graphile/logger@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@graphile/logger/-/logger-0.2.0.tgz#e484ec420162157c6e6f0cfb080fa29ef3a714ba"
+  integrity sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==
+
 "@graphql-codegen/cli@2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.3.1.tgz#66083293b60e3182603d70031210d59e6f1a16e5"
@@ -6019,7 +6024,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/debug@4.1.7":
+"@types/debug@4.1.7", "@types/debug@^4.1.2":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -6344,6 +6349,15 @@
   integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
   dependencies:
     "@types/node" "*"
+
+"@types/pg@>=6 <9":
+  version "8.6.4"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.4.tgz#da1ae9d2f53f2dbfdd2b37e0eb478bf60d517f60"
+  integrity sha512-uYA7UMVzDFpJobCrqwW/iWkFmvizy6knIUgr0Quaw7K1Le3ZnF7hI3bKqFoxPZ+fju1Sc7zdTvOl9YfFZPcmeA==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
 
 "@types/prettier@^2.1.5":
   version "2.4.1"
@@ -8637,6 +8651,11 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
+
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -12854,6 +12873,21 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
+graphile-worker@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.12.2.tgz#d26a00006e1d683c0a11a6d60e21fe9544670a44"
+  integrity sha512-eHDOm15bWDAg4HFWo4FHklIxbtQip44p0nelP7AbkZGvnHKiZMPp8D/hi2HO96bJBHB6A4Zo3zH9o5jBejm5Yw==
+  dependencies:
+    "@graphile/logger" "^0.2.0"
+    "@types/debug" "^4.1.2"
+    "@types/pg" ">=6 <9"
+    chokidar "^3.4.0"
+    cosmiconfig "^7.0.0"
+    json5 "^2.1.3"
+    pg ">=6.5 <9"
+    tslib "^2.1.0"
+    yargs "^16.2.0"
 
 graphql-config@^4.1.0:
   version "4.1.0"
@@ -17209,6 +17243,11 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pako@^1.0.5, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -17474,6 +17513,57 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pg-connection-string@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+  integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.4.1.tgz#0e71ce2c67b442a5e862a9c182172c37eda71e9c"
+  integrity sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==
+
+pg-protocol@*, pg-protocol@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
+  integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
+
+pg-types@^2.1.0, pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+"pg@>=6.5 <9":
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.7.1.tgz#9ea9d1ec225980c36f94e181d009ab9f4ce4c471"
+  integrity sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.5.0"
+    pg-pool "^3.4.1"
+    pg-protocol "^1.5.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+
+pgpass@1.x:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
 
 phin@^2.9.1:
   version "2.9.3"
@@ -17978,6 +18068,28 @@ postcss@^8.2.15, postcss@^8.3.5:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 preact@10.4.1:
   version "10.4.1"
@@ -20151,7 +20263,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@4.1.0, split2@^4.0.0:
+split2@4.1.0, split2@^4.0.0, split2@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809"
   integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==


### PR DESCRIPTION
This was easier than I had feared! https://github.com/graphile/worker seems like a really solid library that works well out of the box. Has support for cron jobs, exponential backoff and job deduping via an arbitrary key out of the box. Even plays nicely with Redwood's way of reloading the server, automatically killing old jobs and then restarting them when the server comes back up!

Added a scheduled job to run the `syncStarknetState` once an hour. This is really just a placeholder to make sure scheduled jobs work—we'll want to be more sophisticated in the way we refresh our cached-profile cache eventually.

The one "downside" is that it doesn't come with a web UI. We'll probably need to build some tools to monitor task status eventually.