### PR TITLE
Use sign-in with Ethereum and Redwood auth

### DIFF
--- a/chain/artifacts/contracts/starknet/zorro.cairo/zorro_abi.json
+++ b/chain/artifacts/contracts/starknet/zorro.cairo/zorro_abi.json
@@ -410,22 +410,22 @@
     },
     {
         "inputs": [],
-        "name": "get_time_windows",
+        "name": "get_periods",
         "outputs": [
             {
-                "name": "PROVISIONAL_TIME_WINDOW",
+                "name": "PROVISIONAL_PERIOD",
                 "type": "felt"
             },
             {
-                "name": "ADJUDICATION_TIME_WINDOW",
+                "name": "ADJUDICATION_PERIOD",
                 "type": "felt"
             },
             {
-                "name": "APPEAL_TIME_WINDOW",
+                "name": "APPEAL_PERIOD",
                 "type": "felt"
             },
             {
-                "name": "SUPER_ADJUDICATION_TIME_WINDOW",
+                "name": "SUPER_ADJUDICATION_PERIOD",
                 "type": "felt"
             }
         ],

--- a/redwood/api/db/migrations/20220127133251_user_sessions/migration.sql
+++ b/redwood/api/db/migrations/20220127133251_user_sessions/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "RoleEnum" AS ENUM ('NOTARY');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "roles" "RoleEnum"[],
+ADD COLUMN     "sessionAuthString" TEXT;
+
+-- CreateTable
+CREATE TABLE "UserSession" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSession_token_key" ON "UserSession"("token");
+
+-- AddForeignKey
+ALTER TABLE "UserSession" ADD CONSTRAINT "UserSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/redwood/api/db/schema.prisma
+++ b/redwood/api/db/schema.prisma
@@ -136,11 +136,32 @@ model Notification {
   updatedAt DateTime @updatedAt
 }
 
+enum RoleEnum {
+  NOTARY
+}
+
 model User {
   id              Int     @id @default(autoincrement())
   ethereumAddress String  @unique
   email           String?
 
+  roles             RoleEnum[]
+  sessionAuthString String?
+
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  UserSession UserSession[]
+}
+
+model UserSession {
+  id Int @id @default(autoincrement())
+
+  userId Int
+  token  String @unique
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  expiresAt DateTime
+
+  User User @relation(fields: [userId], references: [id])
 }

--- a/redwood/api/src/directives/requireAuth/requireAuth.ts
+++ b/redwood/api/src/directives/requireAuth/requireAuth.ts
@@ -3,6 +3,10 @@ import gql from 'graphql-tag'
 import {createValidatorDirective} from '@redwoodjs/graphql-server'
 
 import {requireAuth as applicationRequireAuth} from 'src/lib/auth'
+import {
+  requireAuthDirectiveArgs,
+  requireAuthDirectiveResolver,
+} from 'types/graphql'
 
 export const schema = gql`
   """
@@ -13,7 +17,11 @@ export const schema = gql`
 `
 
 // @ts-expect-error directives aren't strongly typed yet
-const validate = ({directiveArgs}) => {
+const validate: requireAuthDirectiveResolver = ({
+  directiveArgs,
+}: {
+  directiveArgs: requireAuthDirectiveArgs
+}) => {
   const {roles} = directiveArgs
   applicationRequireAuth({roles})
 }

--- a/redwood/api/src/functions/graphql.ts
+++ b/redwood/api/src/functions/graphql.ts
@@ -4,6 +4,8 @@ import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
 
+import {getCurrentUser} from 'src/lib/auth'
+
 import {db} from 'src/lib/db'
 import {logger} from 'src/lib/logger'
 
@@ -14,6 +16,7 @@ import type {} from 'types/environment'
 import 'src/lib/backgroundJobs'
 
 export const handler = createGraphQLHandler({
+  getCurrentUser,
   loggerConfig: {logger, options: {operationName: true}},
   directives,
   sdls,

--- a/redwood/api/src/graphql/unsubmittedProfiles.sdl.ts
+++ b/redwood/api/src/graphql/unsubmittedProfiles.sdl.ts
@@ -38,9 +38,12 @@ export const schema = gql`
       input: UpdateUnsubmittedProfileInput!
     ): UnsubmittedProfile! @skipAuth
 
-    markNotaryViewed(id: ID!): UnsubmittedProfile @skipAuth
-    markNotaryWillApprove(id: ID!): UnsubmittedProfile @skipAuth
-    addNotaryFeedback(id: ID!, feedback: String!): UnsubmittedProfile @skipAuth
-    approveProfile(id: ID!): Boolean! @skipAuth
+    markNotaryViewed(id: ID!): UnsubmittedProfile
+      @requireAuth(roles: ["NOTARY"])
+    markNotaryWillApprove(id: ID!): UnsubmittedProfile
+      @requireAuth(roles: ["NOTARY"])
+    addNotaryFeedback(id: ID!, feedback: String!): UnsubmittedProfile
+      @requireAuth(roles: ["NOTARY"])
+    approveProfile(id: ID!): Boolean! @requireAuth(roles: ["NOTARY"])
   }
 `

--- a/redwood/api/src/graphql/users.sdl.ts
+++ b/redwood/api/src/graphql/users.sdl.ts
@@ -5,8 +5,16 @@ export const schema = gql`
     hasEmail: Boolean!
   }
 
+  type CurrentUser {
+    id: ID!
+    ethereumAddress: String!
+    email: String!
+    roles: [String!]!
+  }
+
   type Query {
     user(ethereumAddress: ID!): User @skipAuth
+    currentUser: CurrentUser @requireAuth
   }
 
   input CreateUserInput {
@@ -16,5 +24,9 @@ export const schema = gql`
 
   type Mutation {
     createUser(input: CreateUserInput!): User! @skipAuth
+
+    requestSessionAuthString(ethereumAddress: String!): String! @skipAuth
+    requestSessionToken(ethereumAddress: String!, signature: String!): String
+      @skipAuth
   }
 `

--- a/redwood/api/src/lib/auth.test.ts
+++ b/redwood/api/src/lib/auth.test.ts
@@ -1,0 +1,36 @@
+import dayjs from 'dayjs'
+import {getCurrentUser} from './auth'
+import {db} from './db'
+
+describe('getCurrentUser', () => {
+  it('finds users with valid sessions', async () => {
+    const user = await db.user.create({
+      data: {
+        ethereumAddress: '0x123',
+      },
+    })
+    await db.userSession.createMany({
+      data: [
+        {
+          userId: user.id,
+          token: 'current_session_token',
+          expiresAt: dayjs().add(1, 'day').toDate(),
+        },
+        {
+          userId: user.id,
+          token: 'expired_session_token',
+          expiresAt: dayjs().subtract(1, 'day').toDate(),
+        },
+      ],
+    })
+
+    const currentUser = await getCurrentUser(null, {
+      token: 'current_session_token',
+    })
+    expect(currentUser?.id).toBe(user.id)
+    const expiredUser = await getCurrentUser(null, {
+      token: 'expired_session_token',
+    })
+    expect(expiredUser).toBe(null)
+  })
+})

--- a/redwood/api/src/services/users/users.test.ts
+++ b/redwood/api/src/services/users/users.test.ts
@@ -1,0 +1,36 @@
+import {Wallet} from 'ethers'
+import {getCurrentUser} from 'src/lib/auth'
+import {db} from 'src/lib/db'
+import {requestSessionAuthString, requestSessionToken} from './users'
+
+describe('auth', () => {
+  it('round-trips a successful login', async () => {
+    const wallet = await Wallet.createRandom()
+
+    const authString = await requestSessionAuthString({
+      ethereumAddress: wallet.address,
+    })
+
+    expect(authString).toMatch(/^Sign this message to authenticate yourself/)
+    expect(authString).toMatch(new RegExp(wallet.address))
+
+    let user = await db.user.findUnique({
+      where: {ethereumAddress: wallet.address},
+    })
+    expect(user?.sessionAuthString).toBe(authString)
+
+    const signature = await wallet.signMessage(authString)
+
+    const token = await requestSessionToken({
+      ethereumAddress: wallet.address,
+      signature,
+    })
+    expect(token).toBeTruthy()
+
+    user = await db.user.findUnique({where: {ethereumAddress: wallet.address}})
+    expect(user?.sessionAuthString).toBe(null)
+
+    const currentUser = await getCurrentUser(null, {token: token!})
+    expect(currentUser!.id).toEqual(user!.id)
+  })
+})

--- a/redwood/api/src/services/users/users.ts
+++ b/redwood/api/src/services/users/users.ts
@@ -1,9 +1,21 @@
 import type {ResolverArgs} from '@redwoodjs/graphql-server'
 import {db} from 'src/lib/db'
-import {MutationcreateUserArgs, QueryuserArgs} from 'types/graphql'
+import {
+  MutationcreateUserArgs,
+  MutationrequestSessionAuthStringArgs,
+  MutationrequestSessionTokenArgs,
+  QueryuserArgs,
+} from 'types/graphql'
+import crypto from 'crypto'
+import dayjs from 'dayjs'
+import {verifyMessage} from 'ethers/lib/utils'
 
 export const user = async ({ethereumAddress}: QueryuserArgs) =>
   db.user.findUnique({where: {ethereumAddress}})
+
+export const currentUser = async () => {
+  db.user.findFirst()
+}
 
 export const createUser = async ({input}: MutationcreateUserArgs) =>
   db.user.create({data: input})
@@ -13,4 +25,48 @@ export const User = {
     _args: void,
     {root}: ResolverArgs<NonNullable<Awaited<ReturnType<typeof user>>>>
   ) => root.email !== null,
+}
+
+export const requestSessionAuthString = async ({
+  ethereumAddress,
+}: MutationrequestSessionAuthStringArgs) => {
+  const nonce = crypto.randomBytes(8).toString('hex')
+  const sessionAuthString = `Sign this message to authenticate yourself at zorro.xyz\n\nAddress: ${ethereumAddress}\nNonce: ${nonce}`
+
+  await db.user.upsert({
+    where: {ethereumAddress},
+    create: {
+      ethereumAddress,
+      sessionAuthString,
+    },
+    update: {sessionAuthString},
+  })
+  return sessionAuthString
+}
+
+export const requestSessionToken = async ({
+  ethereumAddress,
+  signature,
+}: MutationrequestSessionTokenArgs) => {
+  const user = await db.user.findUnique({where: {ethereumAddress}})
+  if (!user?.sessionAuthString) return null
+
+  // Check if the signature is valid
+  const address = verifyMessage(user.sessionAuthString, signature)
+  if (address !== ethereumAddress) return null
+
+  // Clear the auth string to ensure a given signed message can only be used
+  // once.
+  await db.user.update({
+    where: {ethereumAddress},
+    data: {sessionAuthString: null},
+  })
+  const session = await db.userSession.create({
+    data: {
+      User: {connect: {id: user.id}},
+      token: crypto.randomBytes(64).toString('base64url'),
+      expiresAt: dayjs().add(1, 'month').toDate(),
+    },
+  })
+  return session.token
 }

--- a/redwood/web/package.json
+++ b/redwood/web/package.json
@@ -13,6 +13,7 @@
     ]
   },
   "dependencies": {
+    "@apollo/client": "^3.5.8",
     "@argent/get-starknet": "^0.1.4",
     "@chakra-ui/icons": "^1.0.15",
     "@chakra-ui/react": "^1.7.3",
@@ -20,6 +21,7 @@
     "@emotion/styled": "^11",
     "@metamask/jazzicon": "^2.0.0",
     "@reduxjs/toolkit": "^1.7.1",
+    "@redwoodjs/auth": "0.42.0",
     "@redwoodjs/forms": "^0.42.0",
     "@redwoodjs/router": "^0.42.0",
     "@redwoodjs/web": "^0.42.0",
@@ -27,6 +29,7 @@
     "ethers": "^5.5.3",
     "fireworks-js": "^1.3.5",
     "framer-motion": "^4",
+    "graphql": "^16.3.0",
     "ipfs-http-client": "^53.0.1",
     "lodash": "^4.17.21",
     "mic-check": "^1.1.0",

--- a/redwood/web/src/App.tsx
+++ b/redwood/web/src/App.tsx
@@ -1,3 +1,5 @@
+import {AuthProvider} from '@redwoodjs/auth'
+
 import {ChakraProvider} from '@chakra-ui/react'
 import {FatalErrorBoundary, RedwoodProvider} from '@redwoodjs/web'
 import {RedwoodApolloProvider} from '@redwoodjs/web/apollo'
@@ -9,22 +11,25 @@ import store from 'src/state/store'
 import type {} from 'types/environment'
 import theme from './config/theme'
 import {UserContextProvider} from './layouts/UserContext'
+import authClient from './lib/authClient'
 
 const App = () => {
   return (
     <FatalErrorBoundary page={FatalErrorPage}>
       <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
-        <ReactReduxProvider store={store}>
-          <RedwoodApolloProvider>
-            <EthersProvider autoConnect>
-              <UserContextProvider>
-                <ChakraProvider theme={theme}>
-                  <Routes />
-                </ChakraProvider>
-              </UserContextProvider>
-            </EthersProvider>
-          </RedwoodApolloProvider>
-        </ReactReduxProvider>
+        <EthersProvider autoConnect>
+          <ReactReduxProvider store={store}>
+            <AuthProvider type="custom" client={authClient}>
+              <RedwoodApolloProvider>
+                <UserContextProvider>
+                  <ChakraProvider theme={theme}>
+                    <Routes />
+                  </ChakraProvider>
+                </UserContextProvider>
+              </RedwoodApolloProvider>
+            </AuthProvider>
+          </ReactReduxProvider>
+        </EthersProvider>
       </RedwoodProvider>
     </FatalErrorBoundary>
   )

--- a/redwood/web/src/Routes.tsx
+++ b/redwood/web/src/Routes.tsx
@@ -30,6 +30,7 @@ const Routes = () => {
           <Route path="/create-connection" page={CreateConnectionPage} name="createConnection" />
           <Route path="/test-transaction" page={TestTransactionPage} name="testTransaction" />
           <Route notfound page={NotFoundPage} />
+          <Route path="/authenticate" page={AuthenticatePage} name="authenticate" />
         </Set>
       </Set>
     </Router>

--- a/redwood/web/src/config/theme.ts
+++ b/redwood/web/src/config/theme.ts
@@ -2,6 +2,13 @@ import {extendTheme, theme as baseTheme} from '@chakra-ui/react'
 import {StyleFunctionProps} from '@chakra-ui/theme-tools'
 
 const theme = extendTheme({
+  styles: {
+    global: {
+      'html, body': {
+        background: 'gray.50',
+      },
+    },
+  },
   components: {
     Link: {
       variants: {

--- a/redwood/web/src/layouts/UserContext.tsx
+++ b/redwood/web/src/layouts/UserContext.tsx
@@ -1,16 +1,19 @@
 import {useLazyQuery} from '@apollo/client'
 import {useTimeout} from '@chakra-ui/react'
+import {useAuth} from '@redwoodjs/auth'
 import {getAddress} from 'ethers/lib/utils'
 import {useState} from 'react'
 import {UserContextQuery, UserContextQueryVariables} from 'types/graphql'
 import useLocalStorageState from 'use-local-storage-state'
 import {useAccount} from 'wagmi'
+import {CurrentUser} from '../../../api/src/lib/auth'
 
 export type UserContextType =
   | ({
       ethereumAddress: string
       refetch: () => void
       loading: boolean
+      authenticatedUser?: CurrentUser
     } & UserContextQuery)
   | Record<string, undefined>
 
@@ -18,6 +21,9 @@ const UserContext = React.createContext<UserContextType>({})
 
 export function UserContextProvider({children}: {children: React.ReactNode}) {
   const [account] = useAccount()
+  const rwAuth = useAuth()
+
+  const authenticatedUser = rwAuth.currentUser as CurrentUser | undefined
 
   const [ethereumAddress, setEthereumAddress] = useLocalStorageState<
     string | undefined
@@ -53,20 +59,31 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
           id
         }
       }
-    `
+    `,
+    {fetchPolicy: 'cache-and-network'}
   )
 
   React.useEffect(() => {
-    if (initialLoadTimeoutExpired) {
+    if (initialLoadTimeoutExpired)
       setEthereumAddress(
         account.data?.address ? getAddress(account.data?.address) : undefined
       )
-    }
   }, [account.data?.address, initialLoadTimeoutExpired, setEthereumAddress])
 
   React.useEffect(() => {
-    if (ethereumAddress) queryUser({variables: {ethereumAddress}})
-  }, [ethereumAddress, queryUser])
+    if (ethereumAddress && !rwAuth.loading)
+      queryUser({variables: {ethereumAddress}})
+  }, [ethereumAddress, rwAuth.loading])
+
+  // If you disconnect your wallet, we should deauthenticate you as well.
+  React.useEffect(() => {
+    if (
+      authenticatedUser &&
+      authenticatedUser.ethereumAddress !== ethereumAddress
+    ) {
+      rwAuth.logOut()
+    }
+  }, [ethereumAddress, authenticatedUser])
 
   let context = {} as UserContextType
 
@@ -74,8 +91,9 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
     context = {
       ethereumAddress,
       refetch: userContextQuery.refetch,
-      loading: userContextQuery.loading,
-      ...userContextQuery.data,
+      loading: !userContextQuery.data,
+      ...userContextQuery?.data,
+      authenticatedUser,
     } as UserContextType
   }
 

--- a/redwood/web/src/lib/authClient.ts
+++ b/redwood/web/src/lib/authClient.ts
@@ -1,0 +1,20 @@
+import {AuthClient} from '@redwoodjs/auth/dist/authClients'
+
+const TOKEN_KEY = 'ZORRO_AUTH_TOKEN'
+
+const getToken = async () => localStorage.getItem(TOKEN_KEY)
+
+const authClient: AuthClient = {
+  type: 'custom',
+  client: 'custom',
+
+  getToken,
+  getUserMetadata: getToken,
+
+  login: async ({token}: {token: string}) =>
+    localStorage.setItem(TOKEN_KEY, token),
+  logout: async () => localStorage.removeItem(TOKEN_KEY),
+  signup: () => {},
+}
+
+export default authClient

--- a/redwood/web/src/lib/guards.ts
+++ b/redwood/web/src/lib/guards.ts
@@ -1,9 +1,11 @@
-import {routes} from '@redwoodjs/router'
+import {useAuth} from '@redwoodjs/auth'
+import {routes, useLocation} from '@redwoodjs/router'
 import {requestMediaPermissions} from 'mic-check'
 import {useEffect} from 'react'
+import {UserContextType, useUser} from 'src/layouts/UserContext'
 import {useGuard} from 'src/lib/useGuard'
-import {useUser} from 'src/layouts/UserContext'
 import {appNav} from 'src/lib/util'
+import {IterableElement} from 'type-fest'
 
 export const requireWalletConnected = () => {
   const {ethereumAddress} = useUser()
@@ -26,4 +28,22 @@ export const requireCameraAllowed = async () => {
   useEffect(() => {
     requestMediaPermissions().catch(() => appNav(routes.registerAllowCamera()))
   }, [])
+}
+
+export const requireRole = (
+  role: IterableElement<
+    NonNullable<UserContextType['authenticatedUser']>['roles']
+  >
+) => {
+  const {pathname} = useLocation()
+  const {loading, currentUser} = useAuth()
+  const user = currentUser as UserContextType['authenticatedUser']
+
+  const hasRole = user?.roles?.includes(role)
+  useGuard(loading || hasRole, routes.authenticate({next: pathname}), {
+    toast: {
+      status: 'error',
+      title: `You must be signed in to an account with the ${role} role to access this page.`,
+    },
+  })
 }

--- a/redwood/web/src/lib/util.ts
+++ b/redwood/web/src/lib/util.ts
@@ -31,3 +31,6 @@ export const maybeCidToUrl: (value: string) => string = (value) => {
   if (isLocalUrl(value)) return value
   return cidToUrl(value)
 }
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))

--- a/redwood/web/src/pages/AuthenticatePage/AuthenticatePage.tsx
+++ b/redwood/web/src/pages/AuthenticatePage/AuthenticatePage.tsx
@@ -1,0 +1,141 @@
+import {
+  Button,
+  Heading,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Tr,
+} from '@chakra-ui/react'
+import {useAuth} from '@redwoodjs/auth'
+import {navigate} from '@redwoodjs/router'
+import {MetaTags, useMutation} from '@redwoodjs/web'
+import {useCallback, useState} from 'react'
+import ConnectButton from 'src/components/ConnectButton/ConnectButton'
+import {useUser} from 'src/layouts/UserContext'
+import {
+  RequestSessionAuthString,
+  RequestSessionAuthStringVariables,
+  RequestSessionToken,
+  RequestSessionTokenVariables,
+} from 'types/graphql'
+import {useSigner} from 'wagmi'
+
+const AuthenticatePage: React.FC<{next?: string}> = ({next}) => {
+  const {logIn, logOut} = useAuth()
+  const {ethereumAddress, authenticatedUser, loading} = useUser()
+  const [{data: signer}] = useSigner()
+  const [authenticating, setAuthenticating] = useState(false)
+
+  const [requestSessionAuthString] = useMutation<
+    RequestSessionAuthString,
+    RequestSessionAuthStringVariables
+  >(gql`
+    mutation RequestSessionAuthString($ethereumAddress: String!) {
+      requestSessionAuthString(ethereumAddress: $ethereumAddress)
+    }
+  `)
+
+  const [requestSessionToken] = useMutation<
+    RequestSessionToken,
+    RequestSessionTokenVariables
+  >(gql`
+    mutation RequestSessionToken(
+      $ethereumAddress: String!
+      $signature: String!
+    ) {
+      requestSessionToken(
+        ethereumAddress: $ethereumAddress
+        signature: $signature
+      )
+    }
+  `)
+
+  const authenticate = useCallback(async () => {
+    if (!ethereumAddress) return
+    setAuthenticating(true)
+
+    try {
+      const authStringRequest = await requestSessionAuthString({
+        variables: {ethereumAddress},
+      })
+
+      if (!authStringRequest.data)
+        return alert('requestSessionAuthString error')
+
+      if (!signer)
+        return alert('Could not detect signer, is Metamask installed?')
+      const signature = await signer.signMessage(
+        authStringRequest.data.requestSessionAuthString
+      )
+
+      if (!signature) return alert('Signature not complete')
+
+      const sessionTokenRequest = await requestSessionToken({
+        variables: {ethereumAddress, signature},
+      })
+
+      if (!sessionTokenRequest.data) return alert('requestSessionToken error')
+      logIn({token: sessionTokenRequest.data?.requestSessionToken})
+
+      if (next) navigate(next)
+    } finally {
+      setAuthenticating(false)
+    }
+  }, [signer])
+
+  if (loading) return null
+
+  return (
+    <Stack
+      alignSelf="center"
+      alignItems="center"
+      justifyContent="center"
+      width="lg"
+      maxW="100%"
+      backgroundColor="white"
+      shadow="md"
+      padding={8}
+    >
+      <MetaTags title="Authenticate" />
+      {!ethereumAddress && <ConnectButton variant="register-primary" />}
+      {ethereumAddress && !authenticatedUser && (
+        <Button
+          isLoading={authenticating}
+          onClick={authenticate}
+          variant="register-primary"
+        >
+          Authenticate
+        </Button>
+      )}
+
+      {ethereumAddress && authenticatedUser && (
+        <>
+          <Heading size="md">Authenticated User</Heading>
+          <Table>
+            <Tbody>
+              <Tr>
+                <Th>Eth Address</Th>
+                <Td wordBreak="break-all">
+                  {authenticatedUser.ethereumAddress}
+                </Td>
+              </Tr>
+              <Tr>
+                <Th>Roles</Th>
+                <Td>
+                  {authenticatedUser.roles.length > 0
+                    ? authenticatedUser.roles.join(', ')
+                    : 'None'}
+                </Td>
+              </Tr>
+            </Tbody>
+          </Table>
+          <Button onClick={logOut}>Sign out</Button>
+        </>
+      )}
+    </Stack>
+  )
+}
+
+export default AuthenticatePage

--- a/redwood/web/src/pages/Register/AllowCameraPage/AllowCameraPage.tsx
+++ b/redwood/web/src/pages/Register/AllowCameraPage/AllowCameraPage.tsx
@@ -8,7 +8,7 @@ import {
   requestMediaPermissions,
 } from 'mic-check'
 import {useState} from 'react'
-import {requireWalletConnected} from '../guards'
+import {requireWalletConnected} from '../../../lib/guards'
 import RegisterLogo from '../RegisterLogo'
 
 const AllowCameraPage: React.FC = () => {

--- a/redwood/web/src/pages/Register/EmailPage/EmailPage.tsx
+++ b/redwood/web/src/pages/Register/EmailPage/EmailPage.tsx
@@ -15,7 +15,7 @@ import {RLink} from 'src/components/links'
 import {useUser} from 'src/layouts/UserContext'
 import {appNav} from 'src/lib/util'
 import {CreateUserMutation, CreateUserMutationVariables} from 'types/graphql'
-import {requireWalletConnected} from '../guards'
+import {requireWalletConnected} from '../../../lib/guards'
 import RegisterLogo from '../RegisterLogo'
 import Title from '../Title'
 

--- a/redwood/web/src/pages/Register/IntroPage/IntroPage.tsx
+++ b/redwood/web/src/pages/Register/IntroPage/IntroPage.tsx
@@ -7,7 +7,7 @@ import {RLink} from 'src/components/links'
 import {useGuard} from 'src/lib/useGuard'
 import {useUser} from 'src/layouts/UserContext'
 import {save as saveIntendedConnection} from 'src/lib/intendedConnectionStorage'
-import {requireNoExistingProfile} from '../guards'
+import {requireNoExistingProfile} from '../../../lib/guards'
 import RegisterLogo from '../RegisterLogo'
 
 const IntroPage: React.FC<{

--- a/redwood/web/src/pages/Register/PhotoPage/PhotoPage.tsx
+++ b/redwood/web/src/pages/Register/PhotoPage/PhotoPage.tsx
@@ -9,7 +9,7 @@ import {maybeCidToUrl} from 'src/lib/util'
 import {registerSlice} from 'src/state/registerSlice'
 import {useAppDispatch, useAppSelector} from 'src/state/store'
 import {useIsFirstRender} from 'usehooks-ts'
-import {requireCameraAllowed, requireWalletConnected} from '../guards'
+import {requireCameraAllowed, requireWalletConnected} from '../../../lib/guards'
 import UserMediaBox from '../UserMediaBox'
 import {videoConstraints} from '../VideoPage/VideoPage'
 

--- a/redwood/web/src/pages/Register/SubmitPage/SubmitPage.tsx
+++ b/redwood/web/src/pages/Register/SubmitPage/SubmitPage.tsx
@@ -15,7 +15,7 @@ import {
   UpdateUnsubmittedProfileMutation,
   UpdateUnsubmittedProfileMutationVariables,
 } from 'types/graphql'
-import {requireWalletConnected} from '../guards'
+import {requireWalletConnected} from '../../../lib/guards'
 import RegisterLogo from '../RegisterLogo'
 import Title from '../Title'
 import UserMediaBox from '../UserMediaBox'

--- a/redwood/web/src/pages/Register/SubmittedPage/SubmittedPage.tsx
+++ b/redwood/web/src/pages/Register/SubmittedPage/SubmittedPage.tsx
@@ -17,7 +17,7 @@ import {
   RegisterSubmittedPageQueryVariables,
 } from 'types/graphql'
 import {useInterval} from 'usehooks-ts'
-import {requireWalletConnected} from '../guards'
+import {requireWalletConnected} from '../../../lib/guards'
 import RegisterLogo from '../RegisterLogo'
 import Title from '../Title'
 import UserMediaBox from '../UserMediaBox'

--- a/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
+++ b/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
@@ -10,7 +10,7 @@ import {useGuard} from 'src/lib/useGuard'
 import {maybeCidToUrl} from 'src/lib/util'
 import {registerSlice} from 'src/state/registerSlice'
 import {useAppDispatch, useAppSelector} from 'src/state/store'
-import {requireCameraAllowed, requireWalletConnected} from '../guards'
+import {requireCameraAllowed, requireWalletConnected} from '../../../lib/guards'
 import UserMediaBox from '../UserMediaBox'
 
 export const videoConstraints: MediaTrackConstraints = {

--- a/redwood/web/src/pages/UnsubmittedProfilesPage/UnsubmittedProfilesPage.tsx
+++ b/redwood/web/src/pages/UnsubmittedProfilesPage/UnsubmittedProfilesPage.tsx
@@ -1,10 +1,19 @@
 import {Heading, Stack} from '@chakra-ui/layout'
 import {Table, Tbody, Th, Thead, Tr} from '@chakra-ui/react'
 import {MetaTags, useQuery} from '@redwoodjs/web'
+import {requireRole} from 'src/lib/guards'
 import {UnsubmittedProfilesQuery} from 'types/graphql'
 import UnsubmittedProfile from './UnsubmittedProfile'
 
 const UnsubmittedProfilesPage = () => {
+  requireRole('NOTARY')
+  // const {authenticatedUser} = useUser()
+  // useGuard(
+  //   authenticatedUser?.roles?.includes('NOTARY'),
+  //   routes.authenticate({next: routes.unsubmittedProfiles()}),
+  //   {toast: {title: 'You must be a notary to access this page.'}}
+  // )
+
   const {data} = useQuery<UnsubmittedProfilesQuery>(gql`
     query UnsubmittedProfilesQuery {
       unsubmittedProfiles(pendingReview: true) {

--- a/redwood/yarn.lock
+++ b/redwood/yarn.lock
@@ -20,6 +20,24 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.0"
 
+"@apollo/client@^3.5.8":
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.8.tgz#7215b974c5988b6157530eb69369209210349fe0"
+  integrity sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.4"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.0"
+
 "@argent/get-starknet@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@argent/get-starknet/-/get-starknet-0.1.4.tgz#e237a05f5e547795f8a86ae286b75cb2b4aa5883"
@@ -12972,6 +12990,11 @@ graphql@^15.5.1, graphql@^15.6.1:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
   integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
+
+graphql@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
+  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
 gzip-size@5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Allow users to authenticate themselves by signing a server-provided one-time-use string.

This is useful for allowing notaries to submit an "intention to notarize" client-side that we can then trust to perform the actual notarization server-side.

Our original plan was to perform all notarization and profile submission client-side, but unfortunately StarkNet is being slow and unreliable and so we need to be able to track and retry failed submissions, which this allows us to do more easily.