### PR TITLE
Organize API imports

### DIFF
--- a/redwood/web/src/lib/api.ts
+++ b/redwood/web/src/lib/api.ts
@@ -1,0 +1,22 @@
+// Functions we want to expose to the client
+
+export {cairoCompatibleAdd} from '../../../api/src/lib/ipfs'
+export {serializeCid} from '../../../api/src/chain/serializers'
+
+export {
+  erc20Approve,
+  getChallengeDepositSize,
+  submitChallenge,
+  erc20GetAllowance,
+  erc20GetBalanceOf,
+  erc20Mint,
+  exportProfileById,
+  getNumProfiles,
+  notarySubmitProfile,
+} from '../../../api/src/chain/starknet'
+
+export {
+  ZorroAddress,
+  ERC20Address,
+  NotaryAddress,
+} from '../../../api/src/chain/contracts'

--- a/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
+++ b/redwood/web/src/pages/ChallengeProfilePage/ChallengeProfilePage.tsx
@@ -31,15 +31,15 @@ import {
   ChallengePageQueryVariables,
   StatusEnum,
 } from 'types/graphql'
-import {cairoCompatibleAdd} from '../../../../api/src/lib/ipfs'
-import {serializeCid} from '../../../../api/src/chain/serializers'
 import {
+  cairoCompatibleAdd,
+  serializeCid,
   erc20Approve,
   erc20GetBalanceOf,
   getChallengeDepositSize,
   submitChallenge,
-} from '../../../../api/src/chain/starknet'
-import {ZorroAddress} from '../../../../api/src/chain/contracts'
+  ZorroAddress,
+} from 'src/lib/api'
 
 const QUERY = gql`
   query ChallengePageQuery($id: ID!, $resync: Boolean) {

--- a/redwood/web/src/pages/Register/SelfSubmitPage/SelfSubmitPage.tsx
+++ b/redwood/web/src/pages/Register/SelfSubmitPage/SelfSubmitPage.tsx
@@ -2,7 +2,7 @@ import {Link, Spacer, Stack} from '@chakra-ui/layout'
 import {Button, Text} from '@chakra-ui/react'
 import {back} from '@redwoodjs/router'
 import React from 'react'
-import {ZorroAddress} from '../../../../../api/src/chain/contracts'
+import {ZorroAddress} from 'src/lib/api'
 import Title from '../Title'
 
 const SelfSubmitPage = () => {

--- a/redwood/web/src/pages/TestTransactionPage/TestTransactionPage.tsx
+++ b/redwood/web/src/pages/TestTransactionPage/TestTransactionPage.tsx
@@ -5,22 +5,20 @@ import {Box, Heading, Link, Stack, Text} from '@chakra-ui/layout'
 import {FormControl, FormLabel} from '@chakra-ui/react'
 import {MetaTags} from '@redwoodjs/web'
 import {Card} from 'src/components/Card'
-import getNotaryKey from 'src/lib/getNotaryKey'
 import {
+  cairoCompatibleAdd,
   ERC20Address,
-  NotaryAddress,
-  ZorroAddress,
-} from '../../../../api/src/chain/contracts'
-import {
   erc20GetAllowance,
   erc20GetBalanceOf,
   erc20Mint,
   exportProfileById,
   getNumProfiles,
+  NotaryAddress,
   notarySubmitProfile,
-} from '../../../../api/src/chain/starknet'
-import {serializeCid} from '../../../../api/src/chain/serializers'
-import {cairoCompatibleAdd} from '../../../../api/src/lib/ipfs'
+  serializeCid,
+  ZorroAddress,
+} from 'src/lib/api'
+import getNotaryKey from 'src/lib/getNotaryKey'
 
 const ExportProfileById = () => {
   const profileId = React.useRef<HTMLInputElement>(null)


### PR DESCRIPTION
Let's keep a bit of a closer eye on the interface between the server and client code by centralizing all the code the web client imports from the API side in one place.