### PR TITLE
Show approved profiles on the "All Profiles" page optimistically

### DIFF
--- a/redwood/api/db/migrations/20220128204428_connect_registration_attempts_to_cached_profiles/migration.sql
+++ b/redwood/api/db/migrations/20220128204428_connect_registration_attempts_to_cached_profiles/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "RegistrationAttempt_ethereumAddress_approved_idx";
+
+-- AlterTable
+ALTER TABLE "RegistrationAttempt" ADD COLUMN     "profileId" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "RegistrationAttempt_profileId_approved_idx" ON "RegistrationAttempt"("profileId", "approved");
+
+-- AddForeignKey
+ALTER TABLE "RegistrationAttempt" ADD CONSTRAINT "RegistrationAttempt_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "CachedProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/redwood/api/db/schema.prisma
+++ b/redwood/api/db/schema.prisma
@@ -72,6 +72,7 @@ model CachedProfile {
 
   connections Connection[]
 
+  RegistrationAttempt RegistrationAttempt[]
   @@index([cid])
 }
 
@@ -93,8 +94,12 @@ model RegistrationAttempt {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  profileId Int?
+  profile   CachedProfile? @relation(fields: [profileId], references: [id])
+
+  // Used for optimisticallyApprovedRegs
+  @@index([profileId, approved])
   @@index([ethereumAddress])
-  @@index([ethereumAddress, approved])
 }
 
 model Connection {

--- a/redwood/api/src/chain/serializers.test.ts
+++ b/redwood/api/src/chain/serializers.test.ts
@@ -40,6 +40,11 @@ describe('parseEthereumAddress', () => {
     expect(
       parseEthereumAddress('0x334230242D318b5CA159fc38E07dC1248B7b35e40000')
     ).toEqual(null)
+
+    // If an address is in checksum format, the checksum must be correct
+    expect(
+      parseEthereumAddress('0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC72')
+    ).toEqual(null)
   })
 
   test('parses a null address', () => {

--- a/redwood/api/src/functions/getVerifiedExternalAddresses/getVerifiedExternalAddresses.ts
+++ b/redwood/api/src/functions/getVerifiedExternalAddresses/getVerifiedExternalAddresses.ts
@@ -1,6 +1,7 @@
 import {db} from 'src/lib/db'
 import {isVerified} from 'src/services/cachedProfiles/helpers'
 import {Handler} from 'aws-lambda'
+import {getAddress} from 'ethers/lib/utils'
 
 type Params = {
   purposeIdentifier: string
@@ -15,7 +16,7 @@ export const handler: Handler = async (event) => {
   const connections = await db.connection.findMany({
     where: {
       purposeIdentifier,
-      externalAddress: {in: externalAddresses.map((str) => str.toLowerCase())},
+      externalAddress: {in: externalAddresses.map((str) => getAddress(str))},
     },
     include: {
       cachedProfile: true,

--- a/redwood/api/src/graphql/registrationAttempts.sdl.ts
+++ b/redwood/api/src/graphql/registrationAttempts.sdl.ts
@@ -18,6 +18,7 @@ export const schema = gql`
     unreviewedRegistrations: [RegistrationAttempt!]!
       @requireAuth(roles: ["NOTARY"])
     latestRegistration(ethereumAddress: ID!): RegistrationAttempt @skipAuth
+    optimisticallyApprovedRegs: [RegistrationAttempt!]! @skipAuth
   }
 
   input AttemptRegistrationInput {

--- a/redwood/api/src/services/connections/connections.ts
+++ b/redwood/api/src/services/connections/connections.ts
@@ -24,7 +24,7 @@ export const createConnection = async ({
   const createOrUpdate = {
     purposeIdentifier: input.purposeIdentifier,
     signature: input.signature,
-    externalAddress: input.externalAddress.toLowerCase(),
+    externalAddress: input.externalAddress,
     cachedProfile: {connect: {ethereumAddress}},
   }
 

--- a/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
+++ b/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
@@ -22,6 +22,11 @@ const alertUpdated = (
     {}
   )
 
+export const optimisticallyApprovedRegs = async () =>
+  db.registrationAttempt.findMany({
+    where: {approved: true, profileId: null},
+  })
+
 export const unreviewedRegistrations = async () =>
   db.registrationAttempt.findMany({where: {reviewedAt: null}})
 

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -114,6 +114,13 @@ export const importProfile = async (profileId: number) => {
       ...profileFields,
     },
   })
+  persistedProfile.ethereumAddress &&
+    (await db.registrationAttempt.updateMany({
+      where: {ethereumAddress: persistedProfile.ethereumAddress},
+      data: {
+        profileId: persistedProfile.id,
+      },
+    }))
 
   const now = parseTimestamp(exported.now) ?? new Date()
   const status = parseChallengeStatus(parseNumber(exported.current_status))

--- a/redwood/web/src/pages/ProfilesPage/ProfilesPage.stories.tsx
+++ b/redwood/web/src/pages/ProfilesPage/ProfilesPage.stories.tsx
@@ -1,0 +1,203 @@
+import {ProfilesPageQuery} from 'types/graphql'
+import ProfilesPage from './ProfilesPage'
+
+const baseMock: ProfilesPageQuery = {
+  optimisticallyApprovedRegs: [
+    {
+      __typename: 'RegistrationAttempt',
+      ethereumAddress: '0x2Fd1c0659F721ddD06bCeff288B408187C0BB105',
+      photoCid: 'bafybeifph3xf6l2sdpasjszm5glnvtdmk2inz7syjtfok353e56oexlfeu',
+      reviewedAt: '2022-01-28T17:47:26.319Z',
+    },
+    {
+      __typename: 'RegistrationAttempt',
+      ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC74',
+      photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
+      reviewedAt: '2022-01-28T17:47:57.656Z',
+    },
+  ],
+  cachedProfiles: {
+    id: '1',
+    edges: [
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x327e8AE4F9D6CcA061EE8C05dC728b9545C2aC74',
+          photoCid:
+            'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T17:54:26.000Z',
+          id: '13',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x00000000000000000000000000000002Dd656804',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'ADJUDICATION_ROUND_COMPLETED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '12',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x00000000000000000000000000000002Dd656803',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'ADJUDICATION_ROUND_COMPLETED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '11',
+          isVerified: false,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956F0cd',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '10',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956F0Cc',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '9',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956F0cb',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '8',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956F0cA',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '7',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956f0C9',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '6',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956f0C8',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '5',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956f0C7',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '4',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x000000000000000000000000000000004956f0c6',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '3',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x0000000000000000000000000000000007557E7B',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '2',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+      {
+        node: {
+          __typename: 'CachedProfile',
+          ethereumAddress: '0x334230242D318b5CA159fc38E07dC1248B7b35e4',
+          photoCid:
+            'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
+          currentStatus: 'NOT_CHALLENGED',
+          submissionTimestamp: '2022-01-28T09:15:22.000Z',
+          id: '1',
+          isVerified: true,
+        },
+        __typename: 'CachedProfileEdge',
+      },
+    ],
+    pageInfo: {endCursor: '1', hasNextPage: false, __typename: 'PageInfo'},
+    count: 13,
+    __typename: 'CachedProfileConnection',
+  },
+}
+
+export const Page = () => {
+  mockGraphQLQuery('ProfilesPageQuery', baseMock)
+  return <ProfilesPage />
+}
+
+export default {title: 'Pages/ProfilesPage'}


### PR DESCRIPTION
Show approved but unsubmitted profiles on the /profiles page.

Still need to feed these through to the `getVerifiedExternalAddresses` endpoint somehow, and possibly make individual profile pages for them?

<img width="1440" alt="Screen Shot 2022-01-29 at 1 39 59 PM" src="https://user-images.githubusercontent.com/176426/151661392-41001607-7ee9-4e69-9898-f2c2b34ab050.png">

