### PR TITLE
Validate addresses on their way both in and out of the system

### DIFF
--- a/redwood/api/src/directives/validateAddress/validateAddress.test.ts
+++ b/redwood/api/src/directives/validateAddress/validateAddress.test.ts
@@ -1,0 +1,43 @@
+import {mockRedwoodDirective, getDirectiveName} from '@redwoodjs/testing/api'
+
+import validateAddress from './validateAddress'
+
+describe('validateAddress directive', () => {
+  it('declares the directive sdl as schema, with the correct name', () => {
+    expect(validateAddress.schema).toBeTruthy()
+    expect(getDirectiveName(validateAddress.schema)).toBe('validateAddress')
+  })
+
+  it('passes correctly-formed ethereum addresses with checksum', () => {
+    const mockExecution = mockRedwoodDirective(validateAddress, {
+      mockedResolvedValue: '0x334230242D318b5CA159fc38E07dC1248B7b35e4',
+    })
+
+    expect(mockExecution()).toBe('0x334230242D318b5CA159fc38E07dC1248B7b35e4')
+  })
+
+  it('formats correctly-formed ethereum addresses without checksum', () => {
+    const mockExecution = mockRedwoodDirective(validateAddress, {
+      mockedResolvedValue: '0x334230242d318b5ca159fc38e07dc1248b7b35e4',
+    })
+
+    expect(mockExecution()).toBe('0x334230242D318b5CA159fc38E07dC1248B7b35e4')
+  })
+
+  it('fails ethereum addresses with an invalid checksum', () => {
+    const mockExecution = mockRedwoodDirective(validateAddress, {
+      mockedResolvedValue: '0x334230242D318b5CA159fc38E07dC1248B7b35E4',
+    })
+
+    expect(mockExecution).toThrowError()
+  })
+
+  it('fails for random non-address-like strings', () => {
+    const mockExecution = mockRedwoodDirective(validateAddress, {
+      mockedResolvedValue:
+        'put on your sunday clothes when you feel down and out!',
+    })
+
+    expect(mockExecution).toThrowError()
+  })
+})

--- a/redwood/api/src/directives/validateAddress/validateAddress.ts
+++ b/redwood/api/src/directives/validateAddress/validateAddress.ts
@@ -1,0 +1,17 @@
+import {
+  createTransformerDirective,
+  TransformerDirectiveFunc,
+} from '@redwoodjs/graphql-server'
+import {getAddress} from 'ethers/lib/utils'
+
+export const schema = gql`
+  """
+  Checks that the address is a valid Ethereum address. Addresses that are not valid Ethereum addresses or that have a bad checksum are rejected.
+  """
+  directive @validateAddress on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+`
+
+const transform: TransformerDirectiveFunc = ({resolvedValue}) =>
+  getAddress(resolvedValue)
+
+export default createTransformerDirective(schema, transform)

--- a/redwood/api/src/graphql/cachedProfiles.sdl.ts
+++ b/redwood/api/src/graphql/cachedProfiles.sdl.ts
@@ -58,7 +58,8 @@ export const schema = gql`
       @skipAuth
 
     cachedProfile(id: ID!, resync: Boolean = false): CachedProfile @skipAuth
-    cachedProfileByEthereumAddress(ethereumAddress: ID!): CachedProfile
-      @skipAuth
+    cachedProfileByEthereumAddress(
+      ethereumAddress: ID! @validateAddress
+    ): CachedProfile @skipAuth
   }
 `

--- a/redwood/api/src/graphql/registrationAttempts.sdl.ts
+++ b/redwood/api/src/graphql/registrationAttempts.sdl.ts
@@ -17,12 +17,14 @@ export const schema = gql`
   type Query {
     unreviewedRegistrations: [RegistrationAttempt!]!
       @requireAuth(roles: ["NOTARY"])
-    latestRegistration(ethereumAddress: ID!): RegistrationAttempt @skipAuth
+    latestRegistration(
+      ethereumAddress: ID! @validateAddress
+    ): RegistrationAttempt @skipAuth
     optimisticallyApprovedRegs: [RegistrationAttempt!]! @skipAuth
   }
 
   input AttemptRegistrationInput {
-    ethereumAddress: String!
+    ethereumAddress: String! @validateAddress
     photoCid: String!
     videoCid: String!
   }

--- a/redwood/api/src/graphql/users.sdl.ts
+++ b/redwood/api/src/graphql/users.sdl.ts
@@ -18,15 +18,19 @@ export const schema = gql`
   }
 
   input CreateUserInput {
-    ethereumAddress: String!
+    ethereumAddress: String! @validateAddress
     email: String
   }
 
   type Mutation {
     createUser(input: CreateUserInput!): User! @skipAuth
 
-    requestSessionAuthString(ethereumAddress: String!): String! @skipAuth
-    requestSessionToken(ethereumAddress: String!, signature: String!): String
-      @skipAuth
+    requestSessionAuthString(
+      ethereumAddress: String! @validateAddress
+    ): String! @skipAuth
+    requestSessionToken(
+      ethereumAddress: String! @validateAddress
+      signature: String!
+    ): String @skipAuth
   }
 `

--- a/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
+++ b/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
@@ -25,6 +25,7 @@ const alertUpdated = (
 export const optimisticallyApprovedRegs = async () =>
   db.registrationAttempt.findMany({
     where: {approved: true, profileId: null},
+    orderBy: {reviewedAt: 'desc'},
   })
 
 export const unreviewedRegistrations = async () =>

--- a/redwood/scripts/seed.ts
+++ b/redwood/scripts/seed.ts
@@ -19,7 +19,7 @@ export default async () => {
       {
         photoCid: 'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
         videoCid: 'bafybeiaxvwuj72kcknxm5ofryao4pkqpks5qtadrakzcw743jqruli5zku',
-        ethereumAddress: '0x334230242D318b5CA159fc38E07dC1248B7b35e4',
+        ethereumAddress: '0xae10064Aa785805Effbc21e8392d06322b272Ac9',
         approved: false,
         reviewedAt: new Date(),
         reviewedById: notary.id,
@@ -27,7 +27,7 @@ export default async () => {
       {
         photoCid: 'bafybeicxoq24v5sxcz4myt5kx35kluclpoqhsfb2qdf5oevfuklprux2em',
         videoCid: 'bafybeiaxvwuj72kcknxm5ofryao4pkqpks5qtadrakzcw743jqruli5zku',
-        ethereumAddress: '0x334230242D318b5CA159fc38E07dC1248B7b35e5',
+        ethereumAddress: '0xae2C63F5EA082993eCf89E2977724727d47B6d7B',
         approved: true,
         reviewedAt: new Date(),
         reviewedById: notary.id,
@@ -35,32 +35,32 @@ export default async () => {
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC78',
+        ethereumAddress: '0xae33177093b30049461A868db85580BD8d69EC1a',
       },
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC71',
+        ethereumAddress: '0xae4e70F3C1B990bD19c7D961Dc3035b0bafe75f9',
       },
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC72',
+        ethereumAddress: '0xae5CA9aE10A566c4896B32691B9c80a223E295a4',
       },
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC73',
+        ethereumAddress: '0xae6C8c3F5cB12B70C9D27473e076163B22d8b82f',
       },
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC74',
+        ethereumAddress: '0xae731122e5C72D3cEDa26E4be03E79625EfBe472',
       },
       {
         photoCid: 'bafybeif63s5tuz2awex7qkmeki4wby25j4ifraa5lziyn3ifx75rv77qc4',
         videoCid: 'bafybeidadw2rw23ikkrhk7ehcxlaydyor27rslzbubony3qvvgmvt7bww4',
-        ethereumAddress: '0x327e8AE4F9D6Cca061EE8C05dC728b9545c2AC75',
+        ethereumAddress: '0xae82d35eDF5d4424D58537762613364511CD7d3A',
       },
     ],
   })


### PR DESCRIPTION
Allow any address format that passes the `getAddress` check from ethers.js, and transforms it into a canonical form.