### PR TITLE
Fix error in `submitRegistrationAttempt` caused by circular dependency

### DIFF
--- a/redwood/api/src/services/registrationAttempts/helpers.ts
+++ b/redwood/api/src/services/registrationAttempts/helpers.ts
@@ -1,0 +1,11 @@
+import * as Prisma from '@prisma/client'
+import {pusher} from 'src/lib/pusher'
+
+export const alertUpdated = (
+  attempt: Pick<Prisma.RegistrationAttempt, 'ethereumAddress'>
+) =>
+  pusher?.trigger(
+    `registrationAttempt.${attempt.ethereumAddress}`,
+    'updated',
+    {}
+  )

--- a/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
+++ b/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
@@ -1,8 +1,6 @@
-import type * as Prisma from '@prisma/client'
 import {WEB_DOMAIN} from 'src/lib/config'
 import {db} from 'src/lib/db'
 import {NOTARY_PHONE_NUMBERS} from 'src/lib/protocolNotifications'
-import {pusher} from 'src/lib/pusher'
 import {sendMessage} from 'src/lib/twilio'
 import sendNotaryApproved from 'src/mailers/sendNotaryApproved'
 import {backgroundSubmitRegistration} from 'src/tasks/submitRegistrationAttempt'
@@ -13,15 +11,7 @@ import {
   MutationmarkRegistrationViewedArgs,
   QuerylatestRegistrationArgs,
 } from 'types/graphql'
-
-export const alertUpdated = (
-  attempt: Pick<Prisma.RegistrationAttempt, 'ethereumAddress'>
-) =>
-  pusher?.trigger(
-    `registrationAttempt.${attempt.ethereumAddress}`,
-    'updated',
-    {}
-  )
+import {alertUpdated} from './helpers'
 
 export const optimisticallyApprovedRegs = async () =>
   db.registrationAttempt.findMany({

--- a/redwood/api/src/tasks/syncStarknetState.ts
+++ b/redwood/api/src/tasks/syncStarknetState.ts
@@ -20,7 +20,7 @@ import {
   parseChallengeStatus,
 } from 'src/services/cachedProfiles/helpers'
 import {maybeNotify} from 'src/services/notifications/notifications'
-import {alertUpdated} from 'src/services/registrationAttempts/registrationAttempts'
+import {alertUpdated} from 'src/services/registrationAttempts/helpers'
 
 const syncStarknetState = async ({onlyNewProfiles = false} = {}) => {
   console.log('Starting StarkNet sync')


### PR DESCRIPTION
There's an eslint rule that should catch this `eslint-plugin-import/no-cycle`. For some reason it's not working, maybe because of the way Redwood roots work? Should probably get that figured out so this doesn't keep happening.