### PR TITLE
Ensure video is never cropped

### DIFF
--- a/redwood/web/src/pages/Register/MinimalVideoPlayer.tsx
+++ b/redwood/web/src/pages/Register/MinimalVideoPlayer.tsx
@@ -8,13 +8,13 @@ const MinimalVideoPlayer = (props: ReactPlayer['props']) => {
   const startPlaying = () => setIsPlaying(true)
   const stopPlaying = () => setIsPlaying(false)
   return (
-    <Box position="relative">
+    <Box position="relative" h="100%" w="100%">
       <ReactPlayer {...props} playing={isPlaying} onEnded={stopPlaying} />
 
       {!isPlaying && (
         <Center
           onClick={startPlaying}
-          style={{
+          sx={{
             position: 'absolute',
             backgroundColor: 'rgba(0,0,0,0.2)',
             left: 0,
@@ -22,6 +22,7 @@ const MinimalVideoPlayer = (props: ReactPlayer['props']) => {
             bottom: 0,
             right: 0,
             cursor: 'pointer',
+            _hover: {backgroundColor: 'rgba(0,0,0,0.3)'},
           }}
         >
           <Icon as={FaPlay} w={20} h={20} color="white" opacity={0.65} />

--- a/redwood/web/src/pages/Register/SubmitPage/SubmitPage.tsx
+++ b/redwood/web/src/pages/Register/SubmitPage/SubmitPage.tsx
@@ -122,10 +122,10 @@ const SubmitPage = ({initialSubmitProgress = -1}) => {
         />
       ) : (
         <Stack direction="row" px="8" pt="4">
-          <UserMediaBox flex="1">
+          <UserMediaBox>
             <Image src={maybeCidToUrl(registerState.photo)} />
           </UserMediaBox>
-          <UserMediaBox flex="1">
+          <UserMediaBox>
             <MinimalVideoPlayer
               url={maybeCidToUrl(registerState.video)}
               width="100%"

--- a/redwood/web/src/pages/Register/SubmittedPage/SubmittedPage.tsx
+++ b/redwood/web/src/pages/Register/SubmittedPage/SubmittedPage.tsx
@@ -424,10 +424,10 @@ const RegistrationFeedback: React.FC<{
         <Text>"{registrationAttempt.deniedReason}"</Text>
       </TextContainer>
       <Stack direction="row" px="8" pt="4">
-        <UserMediaBox flex="1">
+        <UserMediaBox>
           <Image src={maybeCidToUrl(registrationAttempt.photoCid)} />
         </UserMediaBox>
-        <UserMediaBox flex="1">
+        <UserMediaBox>
           <MinimalVideoPlayer
             url={maybeCidToUrl(registrationAttempt.videoCid)}
             width="100%"

--- a/redwood/web/src/pages/Register/UserMediaBox.tsx
+++ b/redwood/web/src/pages/Register/UserMediaBox.tsx
@@ -1,16 +1,14 @@
-import {AspectRatio, Box, BoxProps, Center} from '@chakra-ui/react'
+import {AspectRatio, Box, Center} from '@chakra-ui/react'
 import BeatLoader from 'react-spinners/BeatLoader'
 
-const UserMediaBox: React.FC<
-  BoxProps & {shouldShowLoadingIndicator?: boolean}
-> = ({shouldShowLoadingIndicator, ...props}) => {
+const UserMediaBox: React.FC<{shouldShowLoadingIndicator?: boolean}> = ({
+  shouldShowLoadingIndicator,
+  children,
+}) => {
   return (
     <AspectRatio
       ratio={16 / 9}
       width="100%"
-      display="flex"
-      justifyContent="center"
-      alignItems="center"
       position="relative"
       backgroundColor="gray.700"
     >
@@ -20,7 +18,16 @@ const UserMediaBox: React.FC<
             <BeatLoader size={20} color="white" />
           </Center>
         )}
-        <Box {...props} />
+        <Center
+          position="absolute"
+          left="0"
+          right="0"
+          top="0"
+          bottom="0"
+          sx={{'img, video': {maxH: '100%'}}}
+        >
+          {children}
+        </Center>
       </Box>
     </AspectRatio>
   )

--- a/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
+++ b/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
@@ -167,7 +167,7 @@ const ConfirmVideoStep = () => {
   return (
     <RegisterScreen
       hero={
-        <UserMediaBox position="relative">
+        <UserMediaBox>
           <MinimalVideoPlayer
             url={maybeCidToUrl(video!)}
             width="100%"


### PR DESCRIPTION
If the user's webcam or video doesn't match our 16/9 aspect ratio, inset their video so the full FOV is visible within the box and just show gray bars for the extra padding.

This ensures you can always see the full video you will be uploading to avoid any embarassing or compromising items near the video edges.

Example with vertical video:

Before:
<img width="533" alt="Screen Shot 2022-02-03 at 8 59 48 AM" src="https://user-images.githubusercontent.com/176426/152311551-74d8b8d5-f246-482b-add0-1e84699a6452.png">

After:
<img width="542" alt="Screen Shot 2022-02-03 at 8 59 29 AM" src="https://user-images.githubusercontent.com/176426/152311499-36a95bc1-a89b-46f5-83b3-518ce6314d57.png">

