### PR TITLE
Let you reuse an existing Ethereum account if you really want to.

### DIFF
--- a/redwood/web/src/components/ConnectButton/ConnectButton.tsx
+++ b/redwood/web/src/components/ConnectButton/ConnectButton.tsx
@@ -51,9 +51,9 @@ export default function ConnectButton({isLoading, ...props}: ButtonProps) {
 // wagmi doesn't support forcing a reconnection, so we're stubbing this in.
 export async function reconnect() {
   await window.ethereum?.request({
-    // @ts-ignore
+    // @ts-expect-error
     method: 'wallet_requestPermissions',
-    // @ts-ignore
+    // @ts-expect-error
     params: [{eth_accounts: {}}],
   })
 }

--- a/redwood/web/src/pages/Register/ConnectWalletPage/ConnectWalletPage.stories.tsx
+++ b/redwood/web/src/pages/Register/ConnectWalletPage/ConnectWalletPage.stories.tsx
@@ -1,10 +1,34 @@
 import RegisterLayout from '../RegisterLayout'
 import ConnectWalletPage from './ConnectWalletPage'
+import {Provider as EthersProvider} from 'wagmi'
+import {StoryMocks} from 'src/lib/StoryMocks'
 
-export const Page = () => (
-  <RegisterLayout>
-    <ConnectWalletPage />
-  </RegisterLayout>
+export const Awaiting_Connection = () => (
+  <EthersProvider>
+    <RegisterLayout>
+      <ConnectWalletPage />
+    </RegisterLayout>
+  </EthersProvider>
+)
+
+export const Reused_Address = () => (
+  <StoryMocks user={{ethereumAddress: '0x456'}}>
+    <EthersProvider>
+      <RegisterLayout>
+        <ConnectWalletPage mockIsFresh={false} />
+      </RegisterLayout>
+    </EthersProvider>
+  </StoryMocks>
+)
+
+export const Reuse_Address_Modal = () => (
+  <StoryMocks user={{ethereumAddress: '0x45645645645645645645'}}>
+    <EthersProvider>
+      <RegisterLayout>
+        <ConnectWalletPage mockIsFresh={false} mockModalOpen />
+      </RegisterLayout>
+    </EthersProvider>
+  </StoryMocks>
 )
 
 export default {title: 'Pages/Register/2. Connect Wallet'}

--- a/redwood/web/src/pages/Register/ConnectWalletPage/ConnectWalletPage.tsx
+++ b/redwood/web/src/pages/Register/ConnectWalletPage/ConnectWalletPage.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {Text} from '@chakra-ui/layout'
+import {Link, Stack, Text} from '@chakra-ui/layout'
 import {routes} from '@redwoodjs/router'
 import ConnectButton, {
   reconnect,
@@ -9,37 +9,124 @@ import {useUser} from 'src/layouts/UserContext'
 import RegisterScreen from '../RegisterScreen'
 import useAsyncEffect from 'use-async-effect'
 
-import {Alert, AlertIcon, AlertTitle, AlertDescription} from '@chakra-ui/react'
+import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  UseDisclosureReturn,
+  Input,
+  Button,
+} from '@chakra-ui/react'
+import {ExternalLinkIcon} from '@chakra-ui/icons'
+import {appNav} from 'src/lib/util'
 
-const AddressAlert = () => (
-  <Alert
-    status="info"
-    variant="subtle"
-    flexDirection="column"
-    alignItems="center"
-    justifyContent="center"
-    textAlign="center"
-    height="200px"
-  >
-    <AlertIcon boxSize="40px" mr={0} />
-    <AlertTitle mt={4} mb={1} fontSize="lg">
-      Please make a fresh address
-    </AlertTitle>
-    <AlertDescription maxWidth="sm">
-      Creating a fresh address protects your privacy. When Metamask pops up,
-      click 'New Account'
-    </AlertDescription>
-  </Alert>
-)
+const ReusingAccountsIsScary = (props: {ctrl: UseDisclosureReturn}) => {
+  const {ethereumAddress} = useUser()
+  const [confirmedAddress, setConfirmedAddress] = useState('')
+  const confirmationMatches =
+    confirmedAddress.toLowerCase() === ethereumAddress.toLowerCase()
+
+  return (
+    <Modal onClose={props.ctrl.onClose} isOpen={props.ctrl.isOpen} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Trying to use an existing address?</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Stack>
+            <Text>
+              We detected previous activity on your connected address,{' '}
+              {ethereumAddress}. You can see that activity{' '}
+              <Link
+                isExternal
+                href={`https://etherscan.io/address/${ethereumAddress}`}
+                display="inline-flex"
+                alignItems="center"
+              >
+                here
+                <ExternalLinkIcon ml={1} />
+              </Link>
+              .
+            </Text>
+            <Text>
+              Since the Zorro profile registry must be public to ensure
+              transparency, signing up for Zorro with your existing address will
+              associate your face and voice with all your previous transactions.
+              This could be a major privacy risk.
+            </Text>
+            <Text>
+              If you're sure you know what you're doing and are ok irreversibly
+              linking your face and voice with your transaction history, copy
+              your Ethereum address into the box below and click "I understand".
+            </Text>
+            <Input
+              placeholder="Ethereum address"
+              value={confirmedAddress}
+              onChange={(e) => setConfirmedAddress(e.target.value)}
+            />
+            <Button
+              colorScheme="red"
+              size="md"
+              alignSelf="center"
+              disabled={!confirmationMatches}
+              onClick={() => appNav(routes.registerAllowCamera())}
+            >
+              I understand
+            </Button>
+          </Stack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+const AddressAlert = (props: {mockModalOpen: boolean}) => {
+  const modalCtrl = useDisclosure({defaultIsOpen: props.mockModalOpen})
+
+  return (
+    <Alert
+      status="info"
+      variant="subtle"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      textAlign="center"
+    >
+      <AlertIcon boxSize="40px" mr={0} />
+      <AlertTitle mt={4} mb={1} fontSize="lg">
+        Reconnect with a fresh address
+      </AlertTitle>
+      <AlertDescription maxWidth="sm">
+        <Text>
+          Creating a fresh address protects your privacy. When Metamask pops up,
+          click 'New Account'.
+        </Text>
+        <Text>
+          <Link onClick={modalCtrl.onOpen}>Learn about reusing addresses.</Link>
+        </Text>
+      </AlertDescription>
+      <ReusingAccountsIsScary ctrl={modalCtrl} />
+    </Alert>
+  )
+}
 
 const ConnectWalletPage: React.FC<{
   purposeIdentifier?: string
   externalAddress?: string
-}> = () => {
+  mockIsFresh?: undefined | false
+  mockModalOpen?: boolean
+}> = ({mockIsFresh = undefined, mockModalOpen = false}) => {
   const {ethereumAddress, registrationAttempt} = useUser()
-  //const [hadEthereumAddressOnLoad] = useState(!!ethereumAddress)
   const [isCheckingFreshness, setIsCheckingFreshness] = useState(false)
-  const [isFresh, setIsFresh] = useState()
+  const [isFresh, setIsFresh] = useState<boolean | undefined>(mockIsFresh)
 
   useGuard(!registrationAttempt, routes.registerSubmitted())
   useGuard(!(isFresh === true), routes.registerAllowCamera())
@@ -67,7 +154,7 @@ const ConnectWalletPage: React.FC<{
       <RegisterScreen
         shouldHideTitle
         title="Use a fresh address"
-        buttonDescription={<AddressAlert />}
+        buttonDescription={<AddressAlert mockModalOpen={mockModalOpen} />}
         PrimaryButtonComponent={!ethereumAddress ? ConnectButton : undefined}
         primaryButtonLabel="Reconnect wallet"
         primaryButtonProps={{onClick: reconnect}}


### PR DESCRIPTION
This adds a pop-up that gives you the option to connect your existing Ethereum account if you jump through a few hoops. Should make our power-users happier while scaring away casual users who might not have thought through the consequences. Text / UX open to suggestions!

<img width="542" alt="Screen Shot 2022-02-03 at 3 54 00 PM" src="https://user-images.githubusercontent.com/176426/152442684-22dd2f48-6791-4233-9507-6ba0f2394620.png">

<img width="539" alt="Screen Shot 2022-02-03 at 2 51 54 PM" src="https://user-images.githubusercontent.com/176426/152442597-00cd5afb-1a69-4285-a996-1d4ba7a89301.png">

