### PR TITLE
Automatically play the video after you finish recording

### DIFF
--- a/redwood/web/src/pages/Register/MinimalVideoPlayer.tsx
+++ b/redwood/web/src/pages/Register/MinimalVideoPlayer.tsx
@@ -4,19 +4,25 @@ import {Box, Icon, Center} from '@chakra-ui/react'
 import {FaPlay} from 'react-icons/fa'
 
 const MinimalVideoPlayer = (
-  props: Omit<ReactPlayer['props'], 'width' | 'height' | 'playing' | 'onEnded'>
+  props: Omit<ReactPlayer['props'], 'width' | 'height' | 'playing'> & {
+    playOnLoad?: boolean
+  }
 ) => {
-  const [isPlaying, setIsPlaying] = useState(false)
+  const {playOnLoad = false, onEnded, ...rest} = props
+  const [isPlaying, setIsPlaying] = useState(playOnLoad)
   const stopPlaying = () => setIsPlaying(false)
   const togglePlaying = () => setIsPlaying((value) => !value)
   return (
     <Box position="relative" h="100%" w="100%">
       <ReactPlayer
-        {...props}
+        {...rest}
         width="100%"
         height="100%"
         playing={isPlaying}
-        onEnded={stopPlaying}
+        onEnded={() => {
+          stopPlaying()
+          onEnded?.()
+        }}
       />
 
       <Center


### PR DESCRIPTION
Automatically play your video back to you once you're done recording, and disable the "Use this video" button until playback finishes.

I thought through different button states we could use to either trigger playback or indicate that you have to play the video before you can continue, and in the end this seemed like the cleanest solution. I'm not 100% sure it's the right solution, but am very interested in seeing how it goes in user testing!