### PR TITLE
Fix twilio not sending messages

### DIFF
--- a/redwood/api/src/lib/twilio.ts
+++ b/redwood/api/src/lib/twilio.ts
@@ -14,19 +14,10 @@ export const sendMessage = async (to: string | string[], body: string) => {
     body,
     from: process.env.TWILIO_NUMBER || '+15555555555',
   }
-  console.log(
-    'sendMessage called',
-    mockCalls,
-    message.body,
-    message.from,
-    to,
-    client
-  )
   if (mockCalls) {
     console.log('Would send', {to, ...message})
   } else {
     const toArray = castArray(to)
-    console.log('toArray', toArray)
     await Promise.all(
       toArray.map((to) => client?.messages.create({to, ...message}))
     )

--- a/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
+++ b/redwood/api/src/services/registrationAttempts/registrationAttempts.ts
@@ -39,7 +39,7 @@ export const attemptRegistration = async ({
   if (pendingRegistration)
     throw new Error('Existing registration pending, cannot resubmit')
 
-  const registration = db.registrationAttempt.create({
+  const registration = await db.registrationAttempt.create({
     data: {
       ...input,
     },
@@ -47,13 +47,6 @@ export const attemptRegistration = async ({
 
   const pendingCount = (await unreviewedRegistrations()).length
 
-  console.log(
-    'atteptRegistration',
-    pendingCount,
-    NOTARY_PHONE_NUMBERS,
-    WEB_DOMAIN,
-    sendMessage
-  )
   if (pendingCount > 0) {
     await sendMessage(
       NOTARY_PHONE_NUMBERS,


### PR DESCRIPTION
Looks like this was a result of forgetting an `await` call when persisting the registration attempt. As a result, the `pendingCount` was 0 and we skipped sending notifications.