### PR TITLE
Don't autodeploy staging

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -65,6 +65,7 @@ services:
         destination: /index.html
     domains:
       - testnet.zorro.xyz
+    autoDeploy: false
 
   - name: staging-api
     type: web
@@ -82,6 +83,7 @@ services:
       - fromGroup: zorro-staging
     domains:
       - staging-api.zorro.xyz
+    autoDeploy: false
 
   # END STAGING SERVICES
 


### PR DESCRIPTION
If we're doing contract changes or data migrations, we may want more control over the deploy pipeline.