### PR TITLE
Avoid running unnecessary jobs in series or parallel

### DIFF
--- a/redwood/api/src/lib/backgroundJobs.ts
+++ b/redwood/api/src/lib/backgroundJobs.ts
@@ -9,13 +9,14 @@ const initialize = async () => {
       // Sync Starknet state every hour at 35 minutes past the hour (arbitrary offset)
       {
         task: 'syncStarknetState',
-        pattern: '35 * * * *',
+        pattern: '08 * * * *',
         options: {
           backfillPeriod: 0,
           maxAttempts: 1,
           queueName: 'scheduled_syncStarknetState',
           priority: 10,
         },
+        identifier: 'scheduled_syncStarknetState',
       },
     ]),
   })

--- a/redwood/api/src/tasks/submitRegistrationAttempt.ts
+++ b/redwood/api/src/tasks/submitRegistrationAttempt.ts
@@ -39,5 +39,10 @@ const submitRegistrationAttempt = async (args: {id: number}) => {
 export default submitRegistrationAttempt
 
 export const backgroundSubmitRegistration = async (id: number) => {
-  quickAddJob({}, 'submitRegistrationAttempt', {id})
+  quickAddJob(
+    {},
+    'submitRegistrationAttempt',
+    {id},
+    {queueName: 'submitRegistrationAttempt'}
+  )
 }


### PR DESCRIPTION
Ensures we don't get in a loop running a bunch of `syncStarknetState` jobs one after another, and also makes sure we don't try to run multiple `submitRegistrationAttempt`s in parallel to decrease our chances of getting 503 errors.