### PR TITLE
Use a video codec that Firefox understands

### DIFF
--- a/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
+++ b/redwood/web/src/pages/Register/VideoPage/VideoPage.tsx
@@ -58,15 +58,10 @@ const RecordVideoStep = ({mockRecording}: {mockRecording?: boolean}) => {
     // here? Just copied the example from
     // https://codepen.io/mozmorris/pen/yLYKzyp?editors=0010
     mediaRecorderRef.current = new MediaRecorder(webcamRef.current.stream, {
-      mimeType: 'video/webm',
+      mimeType: 'video/webm;codecs=vp8,opus',
     })
     mediaRecorderRef.current.addEventListener('dataavailable', ({data}) => {
-      // Create a copy of the blob with the mime type set to 'video/webm'.
-      // Without this at least on MacOS/Chrome I get a mime type of
-      // video/x-matroska;codecs=avc1,opus, which Infura refuses to accept
-      // as a valid mime-type when uploading the video.
-      const video = data.slice(0, data.size, 'video/webm')
-      dispatch(registerSlice.actions.setVideo(URL.createObjectURL(video)))
+      dispatch(registerSlice.actions.setVideo(URL.createObjectURL(data)))
     })
     mediaRecorderRef.current.start()
   }, [webcamRef.current, setIsRecording, mediaRecorderRef.current])


### PR DESCRIPTION
This switches our video recordings to a set of codecs that it seems both Chrome and Firefox are happy with, and removes a weird workaround that the previous codec needed to be accepted by Infura but the new one can get away without.