### PR TITLE
Only ask for a signature if you explicitly clicked the "Connect Wallet" button

### DIFF
--- a/redwood/web/src/layouts/UserContext.tsx
+++ b/redwood/web/src/layouts/UserContext.tsx
@@ -154,7 +154,8 @@ export function UserContextProvider({children}: {children: React.ReactNode}) {
 
     if (connectedAddress !== account.data?.address) {
       await rwAuth.logOut()
-      if (account.data?.address) await maybeAuthenticate(account.data.address)
+      if (account.data?.address && isAuthenticating)
+        await maybeAuthenticate(account.data.address)
     }
   }, [account.data?.address, initialLoadTimeoutExpired, rwAuth.logOut])
 


### PR DESCRIPTION
Don't ask for a signature unless you've clicked "Connect Wallet". This means that eg. if you switch accounts from within Metamask, instead of being asked to sign immediately, you're shown the page in an unconnected state. The next time you click "Connect Wallet", assuming you're already connected, the signature prompt will pop up.